### PR TITLE
[Sheets add-on] Explain how to enable the add-on.

### DIFF
--- a/api/sheets/index.md
+++ b/api/sheets/index.md
@@ -14,4 +14,5 @@ importing data to a spreadsheet.
 
 ## Getting Started
 
-Install the add-on from G Suite Marketplace [here](https://gsuite.google.com/marketplace/app/data_commons/454343067575). It should work on any Google Sheet that you can edit.
+Install the add-on from G Suite Marketplace [here](https://gsuite.google.com/marketplace/app/data_commons/454343067575). To enable the add-on in a document, click "Add-ons > Data Commons > Fill place dcids". You may use the resulting sidebar to start [finding dcids](/api/sheets/get_dcid.md) in the United States, or close it and reopen it at any time. Note that none of the custom functions will work in a given document until you have enabled the add-on by choosing "Fill place dcids".
+![](/assets/sheets_menu_bar.png)


### PR DESCRIPTION
I don't like this behavior, but it appear that to get access to the add-on's custom functions, you need to first enable it by interacting with its menu:

- Another user with the same problem: https://screenshot.googleplex.com/JhHx3s29G28
- A sample app from Google uses the same behavior to enable the app: https://screenshot.googleplex.com/20CysV2rhRb
