### PR TITLE
Remove references to old StatVars from documentation text.

### DIFF
--- a/api/python/stats.md
+++ b/api/python/stats.md
@@ -43,14 +43,14 @@ You can find a list of StatisticalVariables with human-readable names [here](/st
 
 ## Examples
 
-We would like to get the time series of the [male population](https://browser.datacommons.org/kg?dcid=MalePopulation)
+We would like to get the time series of the [male population](https://browser.datacommons.org/kg?dcid=Count_Person_Male)
 in [Arkansas](https://browser.datacommons.org/kg?dcid=geoId/05)
 and [Santa Clara County](https://browser.datacommons.org/kg?dcid=geoId/06085).
 
 ```python
 >>> import datacommons as dc
 >>> dc.set_api_key(YOUR_API_KEY_HERE)
->>> dc.get_stats(["geoId/05", "geoId/06085"], "MalePopulation", obs_dates="all")
+>>> dc.get_stats(["geoId/05", "geoId/06085"], "Count_Person_Male", obs_dates="all")
 {
   'geoId/05': {
     'data': {

--- a/api/rest/stats.md
+++ b/api/rest/stats.md
@@ -37,7 +37,7 @@ You can find a list of StatisticalVariables with human-readable names [here](/st
 
 ```bash
 curl -X POST 'https://api.datacommons.org/bulk/stats?key=API_KEY' \
--d '{ "place": ["geoId/05", "geoId/06085"], "stats_var": "MalePopulation"}'
+-d '{ "place": ["geoId/05", "geoId/06085"], "stats_var": "Count_Person_Male"}'
 ```
 
 ## Success Response

--- a/api/sheets/get_variable.md
+++ b/api/sheets/get_variable.md
@@ -37,7 +37,7 @@ You can find a list of StatisticalVariables with human-readable names [here](/st
 ### Get the total population of Hawaii in 2017.
 
 ```
-=DCGET("geoId/15", "TotalPopulation", 2017)
+=DCGET("geoId/15", "Count_Person", 2017)
 ```
 
 ### Get the population of multiple places with a single function call.


### PR DESCRIPTION
Note that the images for GSheets docs still need updating (can see "TotalPopulation" etc. in the imgs).