### PR TITLE
Layout for REST docs

### DIFF
--- a/_layouts/restdocs.html
+++ b/_layouts/restdocs.html
@@ -4,7 +4,7 @@ layout: default
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Docs -- Data Commons</title>
+    <title>Docs - Data Commons</title>
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/_layouts/restdocs.html
+++ b/_layouts/restdocs.html
@@ -1,0 +1,27 @@
+---
+layout: default
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Docs -- Data Commons</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@600&family=Roboto&display=swap" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url={{page.yaml_title}}></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>


### PR DESCRIPTION
Carolyn asked if there was a way we could convert the boilerplate HTML basis for the Redoc REST API docs into a layout file. This PR implements that idea.

To use, we will replace the html files with markup that looks like this example:

```
---
layout: restdocs
title: Triple
nav_order: 2
yaml_title: triple.yaml
parent: REST
grand_parent: API
---
```