### PR TITLE
Remove references to setting up an API key

### DIFF
--- a/api/pandas/index.md
+++ b/api/pandas/index.md
@@ -22,7 +22,6 @@ Before proceeding, make sure you have followed the setup instructions below.
 To get started using the Pandas API:
 
 *   Install the API using `pip`.
-*   (Optional) Create an API key and enable the **Data Commons API**.
 *   Begin developing with the Pandas API
 
 ### Installing the Pandas API
@@ -37,45 +36,6 @@ For more information about installing `pip` and setting up other parts of
 your Python development environment, please refer to the
 [Python Development Environment Setup Guide](https://cloud.google.com/python/setup.html)
 for Google Cloud Platform.
-
-### Creating an API Key (Optional)
-
-If you would like to provide an API key, follow the steps in [the API setup
-guide](/api/setup.html). Data Commons *does not charge* users, but uses the
-API key for understanding API usage.
-
-With the API key created and Data Commons API activated, we can now get started
-using the pandas API. There are two ways to provide your key
-to the pandas API package.
-
-1.  You can set the API key by calling `datacommons_pandas.set_api_key`.
-    Start by importing `datacommons_pandas`, then set the API key like so.
-
-    ```python
-    import datacommons_pandas as dcpd
-
-    dcpd.set_api_key('YOUR-API-KEY')
-    ```
-
-    This will create an environment variable in your Python runtime called
-    `DC_API_KEY` holding your key. Your key will then be used whenever
-    the package sends a request to the Data Commons graph.
-
-1.  You can export an environment variable in your shell like so.
-
-    ```python
-    export DC_API_KEY='YOUR-API-KEY'
-    ```
-
-    After you've exported the variable, you can start using the Data Commons
-    package.
-
-    ```
-    import datacommons_pandas as dcpd
-    ```
-
-    This route is particularly useful if you are building applications that
-    depend on this API, and are deploying them to hosting services.
 
 ### Using the Pandas API
 

--- a/api/pandas/multivariate_dataframe.md
+++ b/api/pandas/multivariate_dataframe.md
@@ -38,9 +38,6 @@ its `Place` and `StatisticalVariable`.
 
 * `ValueError` - If no statistical values found for the given parameters.
 
-Be sure to initialize the library. See the
-[datacommons_pandas library setup guide](/api/pandas/) for more details.
-
 You can find a list of `StatisticalVariable`s with human-readable names [here](/statistical_variables.html).
 
 ## Examples

--- a/api/python/api_key.md
+++ b/api/python/api_key.md
@@ -4,6 +4,7 @@ title: Set API Key
 nav_order: 1
 parent: Python
 grand_parent: API
+published: false
 ---
 
 # Sets the API key (Optional)

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -20,7 +20,6 @@ Before proceeding, make sure you have followed the setup instructions below.
 To get started using the Python API:
 
 *   Install the API using `pip`.
-*   (Optional) Create an API key and enable the **Data Commons API**.
 *   Begin developing with the Python API
 
 ### Installing the Python API
@@ -35,45 +34,6 @@ For more information about installing `pip` and setting up other parts of
 your Python development environment, please refer to the
 [Python Development Environment Setup Guide](https://cloud.google.com/python/setup.html)
 for Google Cloud Platform.
-
-### Creating an API Key (Optional)
-
-If you would like to provide an API key, follow the steps in [the API setup
-guide](/api/setup.html). Data Commons *does not charge* users, but uses the
-API key for understanding API usage.
-
-With the API key created and Data Commons API activated, we can now get started
-using the Data Commons Python API. There are two ways to provide your key
-to the Python API package.
-
-1.  You can set the API key by calling `datacommons.set_api_key`.
-    Start by importing `datacommons`, then set the API key like so.
-
-    ```python
-    import datacommons as dc
-
-    dc.set_api_key('YOUR-API-KEY')
-    ```
-
-    This will create an environment variable in your Python runtime called
-    `DC_API_KEY` holding your key. Your key will then be used whenever
-    the package sends a request to the Data Commons graph.
-
-1.  You can export an environment variable in your shell like so.
-
-    ```python
-    export DC_API_KEY='YOUR-API-KEY'
-    ```
-
-    After you've exported the variable, you can start using the Data Commons
-    package.
-
-    ```
-    import datacommons as dc
-    ```
-
-    This route is particularly useful if you are building applications that
-    depend on this API, and are deploying them to hosting services.
 
 ### Using the Python API
 

--- a/api/python/observation.md
+++ b/api/python/observation.md
@@ -58,9 +58,7 @@ if such an observation does not exist.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/place_in.md
+++ b/api/python/place_in.md
@@ -30,9 +30,7 @@ A `dict` from a given dcid to a list of places identified by dcids of the given
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/place_obs.md
+++ b/api/python/place_obs.md
@@ -39,9 +39,7 @@ for more details on how the return value is structured.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/pop_obs.md
+++ b/api/python/pop_obs.md
@@ -32,9 +32,7 @@ See example below for more detail about how the returned `dict` is structured.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/population.md
+++ b/api/python/population.md
@@ -41,9 +41,7 @@ of the `dict` if such a population does not exist.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/property_label.md
+++ b/api/python/property_label.md
@@ -26,9 +26,7 @@ Otherwise, they correspond to edges directed towards the given nodes.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/property_value.md
+++ b/api/python/property_value.md
@@ -34,9 +34,7 @@ they correspond to edges directed towards the given nodes.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/query.md
+++ b/api/python/query.md
@@ -44,9 +44,7 @@ if and only if `select` returns `True` for that row.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/python/triple.md
+++ b/api/python/triple.md
@@ -38,9 +38,7 @@ following fields. Note that not all fields are always included in each triple.
 
 **Raises**
 
-*   `ValueError` - If the payload returned by the Data Commons REST API is malformed or the API key is not set.
-
-Be sure to initialize the library, and specify the API key. Check the [Python library setup guide](/api/python/) for more details.
+*   `ValueError` - If the payload returned by the Data Commons REST API is malformed.
 
 ## Examples
 

--- a/api/rest/index.md
+++ b/api/rest/index.md
@@ -12,29 +12,3 @@ programmatically access nodes in the Data Commons knowledge graph. This package
 allows users to explore the structure of the graph, integrate statistics from
 the graph into data analysis applications and much more. Please see the
 [overview](/api) for more details on the design and structure of the API.
-
-Before proceeding, make sure you have followed the setup instructions below.
-
-## Creating an API key (Optional)
-
-If you would like to provide an API key, follow the steps in [the API setup
-guide](/api/setup.html). Data Commons *does not charge* users, but uses the
-API key for understanding API usage.
-
-You can provide the API key as a get parameter to all REST API calls. As an example:
-
-```bash
-curl -X POST 'https://api.datacommons.org/node/observations' \
--d '{"dcids": ["dc/p/x6t44d8jd95rd", "dc/p/lr52m1yr46r44"], \
-     "measuredProperty": "count", \
-     "statsType": "measuredValue", \
-     "observationDate": "2018-12", \
-     "observationPeriod": "P1M", \
-     "measurementMethod": "BLSSeasonallyAdjusted"}'
-```
-
-### Using the REST API
-
-You are now ready to go! From here you can view our
-[tutorials](/tutorials.html) on how to use the API to perform certain tasks,
-or see a full list of calls available for use in the left navigation menu.

--- a/api/rest/observation.md
+++ b/api/rest/observation.md
@@ -53,10 +53,6 @@ statistical populations, constrained by the given observation's property values.
     specified, set this to an empty string.
 
 
-**Optional Arguments**:
-
-*   `key`: Your API key.
-
 ## POST Request
 
 **Example**

--- a/api/rest/place_in.md
+++ b/api/rest/place_in.md
@@ -26,9 +26,6 @@ contained within, of a specified type.
     DCIDs to filter by. E.g. `City` and `County` are contained within `State`. For a
     full list of available types, see [`subClassOf Place`](https://datacommons.org/browser/Place).
 
-**Optional Arguments**:
-
-*   `key`: Your API key.
 
 ## GET Request
 

--- a/api/rest/place_obs.md
+++ b/api/rest/place_obs.md
@@ -25,8 +25,6 @@ given a set of constraints on the
 
 **Required Arguments**:
 
-*   `key`: Your API key.
-
 *   `placeType`: The type of the
     [`Place`](https://datacommons.org/browser/Place) to query for.
 
@@ -36,8 +34,6 @@ given a set of constraints on the
 *   `observationDate`: The observation date in ISO-8601 format.
 
 **Optional Arguments**:
-
-*   `key`: Your API key.
 
 *   `pvs`: A list of objects with constraining `property` and `value` fields
     that the `StatisticalPopulation` should be constrained by.

--- a/api/rest/pop_obs.md
+++ b/api/rest/pop_obs.md
@@ -22,14 +22,9 @@ this node.
 
 **Required Arguments**:
 
-*   `key`: Your API key.
-
 *   `dcid`: The DCID of the node (mostly with type of a `Place` like `City`,
     `County` or organization like `School`).
 
-**Optional Arguments**:
-
-*   `key`: Your API key.
 
 ## GET Request
 

--- a/api/rest/population.md
+++ b/api/rest/population.md
@@ -35,8 +35,6 @@ for these places, constrained by the given property values.
 
 **Optional Arguments**:
 
-*   `key`: Your API key.
-
 *   `pvs`: A list of objects with constraining `property` and `value` fields
     that the `StatisticalPopulation` should be constrained by.
 

--- a/api/rest/property_label.md
+++ b/api/rest/property_label.md
@@ -20,10 +20,6 @@ Returns the labels of properties defined for the given DCID's
 
 *   `dcids`: A list of nodes to query, identified by their DCID's.
 
-**Optional Arguments**:
-
-*   `key`: Your API key.
-
 ## GET Request
 
 **Example**

--- a/api/rest/property_value.md
+++ b/api/rest/property_value.md
@@ -29,7 +29,6 @@ This endpoint is suitable for situations in which you have a node or list of nod
     the value refers to a node.
 *   `direction`: The label's direction. Only valid values are `out` (returning response nodes directed towards the requested node) and `in` (returning response nodes directed away from the request node).
 *   `limit`: (≤ 500) Maximum number of values returned per node.
-*   `key`: Your API key.
 
 ## How to construct a request to the property value endpoint
 

--- a/api/rest/query.md
+++ b/api/rest/query.md
@@ -32,9 +32,6 @@ This API only supports a subset of SPARQL keywords including:
 In the query, each variable should have a `typeOf` condition, e.g. `"?var typeOf
 City ."`.
 
-**Optional Arguments**:
-
-*   `key`: Your API key.
 
 ## POST Request
 
@@ -102,22 +99,5 @@ curl -X POST 'https://api.datacommons.org/query'
 {
   "code": 2,
   "message": "missing required arguments"
-}
-```
-
-### **Code**: `401 Unauthorized`
-
-**Request example:** (API key not specified)
-
-```bash
-curl -X POST 'https://api.datacommons.org/query'
-```
-
-**Response content example**
-
-```json
-{
-  "code": 16,
-  "message": "Method doesn't allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API."
 }
 ```

--- a/api/rest/stats.md
+++ b/api/rest/stats.md
@@ -28,10 +28,6 @@ See the [full list of StatisticalVariables](/statistical_variables.html).
 
 You can find a list of StatisticalVariables with human-readable names [here](/statistical_variables.html).
 
-**Optional Arguments**:
-
-*   `key`: Your API key.
-
 ## POST Request
 
 **Example**

--- a/api/rest/triple.md
+++ b/api/rest/triple.md
@@ -31,8 +31,6 @@ label of a directed edge from *s* to *o* (sometimes also called the *predicate*)
 *   `limit`: The maximum number of triples per combination of property and type
     associated with nodes linked by that property to fetch, up to *500*.
 
-*   `key`: Your API key.
-
 ## GET Request
 
 **Example**
@@ -135,22 +133,5 @@ curl -X POST 'https://api.datacommons.org/node/triples' -d '{"dcids": []}'
 {
   "code": 2,
   "message": "must provide DCIDs"
-}
-```
-
-### **Code**: `401 Unauthorized`
-
-**Request example:** (API key not specified)
-
-```bash
-curl -X POST 'https://api.datacommons.org/node/triples'
-```
-
-**Response content example**
-
-```json
-{
-  "code": 16,
-  "message": "Method doesn't allow unregistered callers (callers without established identity). Please use API Key or other form of API consumer identity to call this API."
 }
 ```


### PR DESCRIPTION
I left the instructions for creating / setting the API key unpublished, if we need to resurrect it in the future.

@KilimAnnejaro fyi