### PR TITLE
Ensure that CNAME is kept when jekyll is built for deploy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,3 +39,5 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
+
+include: ['CNAME']


### PR DESCRIPTION
The github action we use to build and deploy the site does a clean build every time, which is then force pushed to github. In the process, the CNAME file was lost in the gh-pages branch (and we lost our custom domain).

This change ensures that the file gets copied over during build / deploy.