### PR TITLE
Unpublish style guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _site/
 vendor/
 .bundle/
 .vscode/
+.jekyll-cache

--- a/_config.yml
+++ b/_config.yml
@@ -39,5 +39,6 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
+  - STYLE_GUIDE.md
 
 include: ['CNAME']


### PR DESCRIPTION
The style guide got published, so adding it to the exclude list from jekyll processing

![image](https://user-images.githubusercontent.com/6052978/104274080-e885c900-5454-11eb-87b9-be58d91507bc.png)

