### PR TITLE
Update env for deploy action

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -9,18 +9,18 @@ on:
 
 jobs:
   github-pages:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       
       # Use GitHub Actions' cache to shorten build times and decrease load on servers
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
           restore-keys: |
             ${{ runner.os }}-gems-
       
-      - uses: helaili/jekyll-action@2.0.1
+      - uses: helaili/jekyll-action@v2
         env:
           JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}


### PR DESCRIPTION
Actions weren't running because the requested environment was obsolete. Also pull latest version of the action