### PR TITLE
Add deployment status badge to the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build and deploy to GitHub Pages](https://github.com/datacommonsorg/docsite/actions/workflows/github-pages.yml/badge.svg)](https://github.com/datacommonsorg/docsite/actions/workflows/github-pages.yml)
+
 # Data Commons Documentation Site
 
 This repo hosts Data Commons API documentation


### PR DESCRIPTION
We hadn't caught the fact that deployments were failing for a few months. Bringing this to the fore so it's more obvious.

![image](https://user-images.githubusercontent.com/6052978/148606983-afa86527-cb70-43cb-8858-9b3b68edbea0.png)
