### PR TITLE
[v1 API Docs] API key documentation

### DIFF
--- a/_sass/api_documentation.scss
+++ b/_sass/api_documentation.scss
@@ -40,6 +40,7 @@ $shadow: drop-shadow(0 0 0.2em rgba(0, 0, 0, 0.1));
 %code-box {
   background: $code-background-color;
   font: 0.8em monospace;
+  line-height: 1.5;
 }
 
 /** "Required" and "Optional" labels for parameters */
@@ -179,6 +180,7 @@ optional-tag {
     max-height: 20em;
     overflow-wrap: break-word;
     overflow-y: auto;
+    line-height: 1.5;
   }
 
   .highlight {

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -41,7 +41,7 @@ URL:
 https://api.datacommons.org/v1/bulk/observations/point
 
 Header:
-key: {your_api_key}
+X-API-Key: {your_api_key}
 
 JSON Data:
 {
@@ -166,7 +166,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/observations/point \
---header 'key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
+--header 'X-API-Key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -76,7 +76,7 @@ There are no path parameters for this endpoint.
  
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
-| X-API-key <br /> <required-tag>Required</required-tag>   | string | Your API key, passed as a header. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | entities <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the entities the variables describe. |
 | variables <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the variables to query observations for.|
 | date <br /> <optional-tag>Optional</optional-tag> | string | Datetime of measurement of the value requested in ISO 8601 format. To see the dates available, look up the variable in the [Statistical Variable Explorer](https://datacommons.org/tools/statvar). If date is not provided, the latest available datapoint is returned.  |
@@ -151,7 +151,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&date=2019&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&date=2019&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
  
@@ -166,7 +166,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/observations/point \
---header 'X-API-Key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}
@@ -255,7 +255,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&all_facets=true&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&all_facets=true&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
  

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -76,7 +76,7 @@ There are no path parameters for this endpoint.
  
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| X-API-key <br /> <required-tag>Required</required-tag>   | string | Your API key, passed as a header. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | entities <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the entities the variables describe. |
 | variables <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the variables to query observations for.|
 | date <br /> <optional-tag>Optional</optional-tag> | string | Datetime of measurement of the value requested in ISO 8601 format. To see the dates available, look up the variable in the [Statistical Variable Explorer](https://datacommons.org/tools/statvar). If date is not provided, the latest available datapoint is returned.  |

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -33,12 +33,15 @@ Retrieve a specific observation at a set date from multiple variables for multip
 </div> 
 
 <div id="GET-request" class="api-tabcontent api-signature">
-https://api.datacommons.org/v1/bulk/observations/point?entities={entity_dcid_1}&entities={entity_dcid_2}&variables={variable_dcid_1}&variables={variable_dcid_2}
+https://api.datacommons.org/v1/bulk/observations/point?entities={entity_dcid_1}&entities={entity_dcid_2}&variables={variable_dcid_1}&variables={variable_dcid_2}&key={your_api_key}
 </div>
 
 <div id="POST-request" class="api-tabcontent api-signature">
 URL:
 https://api.datacommons.org/v1/bulk/observations/point
+
+Header:
+key: {your_api_key}
 
 JSON Data:
 {
@@ -73,6 +76,7 @@ There are no path parameters for this endpoint.
  
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | entities <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the entities the variables describe. |
 | variables <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the variables to query observations for.|
 | date <br /> <optional-tag>Optional</optional-tag> | string | Datetime of measurement of the value requested in ISO 8601 format. To see the dates available, look up the variable in the [Statistical Variable Explorer](https://datacommons.org/tools/statvar). If date is not provided, the latest available datapoint is returned.  |
@@ -147,7 +151,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&date=2019'
+'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&date=2019&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
  
@@ -162,7 +166,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/observations/point \
---header 'content-type: application/json' \
+--header 'key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}
@@ -251,7 +255,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&all_facets=true'
+'https://api.datacommons.org/v1/bulk/observations/point?entities=geoId/06&entities=geoId/48&variables=Count_Person_Male&variables=Count_Person_Female&all_facets=true&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
  

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -69,7 +69,7 @@ There are no path parameters for this endpoint.
 
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
-| X-API-Key <br /> <required-tag>Required</required-tag>   | string | Your API key, passed as a header. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | entities <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the entities the variables describe. |
 | variables <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the variables to query observations for.
 | all_facets <br /><optional-tag>Optional</optional-tag> | Boolean | Whether to return data from all [facets](/glossary.html#facet) available. If true, data from all facets available will be returned. If false, only data from the [preferred facet](/glossary.html#preferred-facet) will be returned. Defaults to false.
@@ -177,7 +177,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/observations/series?entities=geoId/51&entities=geoId/48&variables=Annual_Consumption_Coal_ElectricPower&variables=WithdrawalRate_Water&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/bulk/observations/series?entities=geoId/51&entities=geoId/48&variables=Annual_Consumption_Coal_ElectricPower&variables=WithdrawalRate_Water&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
  
@@ -192,7 +192,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/observations/series \
---header 'X-API-Key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
 --data '{"entities":["geoId/51", "geoId/48"], "variables":["Annual_Consumption_Coal_ElectricPower", "WithdrawalRate_Water"]}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -69,7 +69,7 @@ There are no path parameters for this endpoint.
 
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| X-API-Key <br /> <required-tag>Required</required-tag>   | string | Your API key, passed as a header. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | entities <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the entities the variables describe. |
 | variables <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the variables to query observations for.
 | all_facets <br /><optional-tag>Optional</optional-tag> | Boolean | Whether to return data from all [facets](/glossary.html#facet) available. If true, data from all facets available will be returned. If false, only data from the [preferred facet](/glossary.html#preferred-facet) will be returned. Defaults to false.

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -29,13 +29,16 @@ Retrieve a series of observations for multiple variables and entities.
 
 
 <div id="GET-request" class="api-tabcontent api-signature">
-https://api.datacommons.org/v1/bulk/observations/series?entities={entity_dcid_1}&entities={entity_dcid_2}&variables={variable_dcid_1}&variables={variable_dcid_2}
+https://api.datacommons.org/v1/bulk/observations/series?entities={entity_dcid_1}&entities={entity_dcid_2}&variables={variable_dcid_1}&variables={variable_dcid_2}&key={your_api_key}
 </div>
 
 
 <div id="POST-request" class="api-tabcontent api-signature">
 URL:
 https://api.datacommons.org/v1/bulk/observations/series
+
+Header:
+key: {your_api_key}
 
 JSON Data:
 {
@@ -66,6 +69,7 @@ There are no path parameters for this endpoint.
 
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | entities <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the entities the variables describe. |
 | variables <br /><required-tag>Required</required-tag> | Repeated string | [DCIDs](/glossary.html#dcid) of the variables to query observations for.
 | all_facets <br /><optional-tag>Optional</optional-tag> | Boolean | Whether to return data from all [facets](/glossary.html#facet) available. If true, data from all facets available will be returned. If false, only data from the [preferred facet](/glossary.html#preferred-facet) will be returned. Defaults to false.
@@ -173,7 +177,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/observations/series?entities=geoId/51&entities=geoId/48&variables=Annual_Consumption_Coal_ElectricPower&variables=WithdrawalRate_Water'
+'https://api.datacommons.org/v1/bulk/observations/series?entities=geoId/51&entities=geoId/48&variables=Annual_Consumption_Coal_ElectricPower&variables=WithdrawalRate_Water&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
  
@@ -188,7 +192,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/observations/series \
---header 'content-type: application/json' \
+--header 'key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
 --data '{"entities":["geoId/51", "geoId/48"], "variables":["Annual_Consumption_Coal_ElectricPower", "WithdrawalRate_Water"]}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -38,7 +38,7 @@ URL:
 https://api.datacommons.org/v1/bulk/observations/series
 
 Header:
-key: {your_api_key}
+X-API-Key: {your_api_key}
 
 JSON Data:
 {
@@ -192,7 +192,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/observations/series \
---header 'key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
+--header 'X-API-Key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
 --data '{"entities":["geoId/51", "geoId/48"], "variables":["Annual_Consumption_Coal_ElectricPower", "WithdrawalRate_Water"]}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/getting_started.md
+++ b/api/rest/v1/getting_started.md
@@ -127,7 +127,7 @@ For POST requests, pass the key as a header. For example, in cURL, this looks li
 ```bash
 curl -X POST \
 --url https://api.datacommons.org/v1/bulk/end/point \
---header 'key: <YOUR_KEY_HERE>' \
+--header 'X-API-Key: <YOUR_KEY_HERE>' \
 --data '{
   "entities": [
     "entity_dcid_1",

--- a/api/rest/v1/getting_started.md
+++ b/api/rest/v1/getting_started.md
@@ -148,7 +148,7 @@ We've provided a trial API key for general public use.  This key will let you tr
 
 <div markdown="span" class="alert alert-secondary" role="alert" style="color:black; font-size: 0.8em">
    <b>Trial Key: </b>
-   `AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo`
+   `AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI`
 </div>
 
 <b>The trial key is capped with a limited quota for requests.</b> If you are planning on using our APIs more rigorously (e.g. for personal or school projects, developing applications, etc.) please email us at [support@datacommons.org](mailto:support@datacommons.org?subject=API Key Request) with "API Key Request" in the subject to request an official key without any quota limits. We'll be happy to hear from you!

--- a/api/rest/v1/getting_started.md
+++ b/api/rest/v1/getting_started.md
@@ -102,17 +102,57 @@ curl -X POST \
   ]
 }'
 ```
-
-<!--
-
-##### Pagination
-
-(Description of how pagination for bulk APIs works will go here.)
-
 ### Authentication
+{: #authentication}
 
-(Details about getting and setting API keys will go here.)
--->
+<div markdown="span" class="alert alert-danger" role="alert" style="color:black; font-size: 0.8em">
+   <span class="material-icons md-16">priority_high</span><b>Important:</b><br />
+   API keys are now required. To use the REST API, a valid API key must be included in all requests.
+</div>
+
+#### Using API Keys
+API keys are required in any REST API request. To include an API key, add your API key to the URL as a query parameter by appending `?key=<YOUR_API_KEY_HERE>`. 
+
+For GET requests, this looks like:
+```bash
+https://api.datacommons.org/v1/end/point?key=<YOUR_KEY_HERE>
+```
+
+If the key is not the first query parameter, use `&key=<YOUR_API_KEY_HERE>` instead. This looks like:
+```bash
+https://api.datacommons.org/v1/end/point?query=value&key=<YOUR_KEY_HERE>
+```
+
+For POST requests, pass the key as a header. For example, in cURL, this looks like:
+```bash
+curl -X POST \
+--url https://api.datacommons.org/v1/bulk/end/point \
+--header 'key: <YOUR_KEY_HERE>' \
+--data '{
+  "entities": [
+    "entity_dcid_1",
+    "entity_dcid_2",
+    ...
+  ],
+  "variables: [
+    "variable_dcid_1",
+    "variable_dcid_2",
+    ...
+  ]
+}'
+``` 
+
+#### Getting API Keys
+
+We've provided a trial API key for general public use.  This key will let you try the API and make single requests.
+
+<div markdown="span" class="alert alert-secondary" role="alert" style="color:black; font-size: 0.8em">
+   <b>Trial Key: </b>
+   `AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo`
+</div>
+
+<b>The trial key is capped with a limited quota for requests.</b> If you are planning on using our APIs more rigorously (e.g. for personal or school projects, developing applications, etc.) please email us at [support@datacommons.org](mailto:support@datacommons.org?subject=API Key Request) with "API Key Request" in the subject to request an official key without any quota limits. We'll be happy to hear from you!
+
 
 ## Troubleshooting
 
@@ -151,8 +191,6 @@ This is most commonly seen when the endpoint is misspelled or otherwise malforme
 This is most commonly seen when your request is missing a required path parameter. Make sure endpoints and parameters are both spelled correctly and provided in the right order.
 
 #### Empty Response
-
-
 ```json
 {}
 ```

--- a/api/rest/v1/observations_point.md
+++ b/api/rest/v1/observations_point.md
@@ -23,7 +23,7 @@ GET Request
 {: .api-header}
 
 <div class="api-signature">
-https://api.datacommons.org/v1/observations/point/{ENTITY_DCID}/{VARIABLE_DCID}
+https://api.datacommons.org/v1/observations/point/{ENTITY_DCID}/{VARIABLE_DCID}?key={your_api_key}
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -41,6 +41,7 @@ https://api.datacommons.org/v1/observations/point/{ENTITY_DCID}/{VARIABLE_DCID}
 
 | Name                                              | Type | Description                                                                                                                                                                                                                                                             |
 | ------------------------------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | date <br /> <optional-tag>Optional</optional-tag> | type | Datetime of measurement of the value requested in ISO 8601 format. To see the dates available, look up the variable in the [Statistical Variable Explorer](https://datacommons.org/tools/statvar). If date is not provided, the latest available datapoint is returned. |
 {: .doc-table }
 
@@ -77,7 +78,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/observations/point/country/USA/Count_Person'
+'https://api.datacommons.org/v1/observations/point/country/USA/Count_Person?key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
 
@@ -106,7 +107,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/observations/point/geoId/06/Annual_Generation_Electricity?date=2018'
+'https://api.datacommons.org/v1/observations/point/geoId/06/Annual_Generation_Electricity?date=2018&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
 

--- a/api/rest/v1/observations_point.md
+++ b/api/rest/v1/observations_point.md
@@ -78,7 +78,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/observations/point/country/USA/Count_Person?key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/observations/point/country/USA/Count_Person?key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
 
@@ -107,7 +107,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/observations/point/geoId/06/Annual_Generation_Electricity?date=2018&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/observations/point/geoId/06/Annual_Generation_Electricity?date=2018&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
 

--- a/api/rest/v1/observations_series.md
+++ b/api/rest/v1/observations_series.md
@@ -85,7 +85,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/observations/series/wikidataId/Q987/Mean_Rainfall?key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/observations/series/wikidataId/Q987/Mean_Rainfall?key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
  

--- a/api/rest/v1/observations_series.md
+++ b/api/rest/v1/observations_series.md
@@ -22,7 +22,7 @@ GET Request
 {: .api-header}
 
 <div class="api-signature">
-https://api.datacommons.org/v1/observations/series/{ENTITY_DCID}/{VARIABLE_DCID}
+https://api.datacommons.org/v1/observations/series/{ENTITY_DCID}/{VARIABLE_DCID}?key={your_api_key}
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -38,7 +38,10 @@ https://api.datacommons.org/v1/observations/series/{ENTITY_DCID}/{VARIABLE_DCID}
  
 ### Query Parameters
 
-There are no query string parameters for this method.
+| Name   | Type | Description  |
+| -------| ---- | ------------ |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+{: .doc-table }
  
 ## Response
 
@@ -82,7 +85,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/observations/series/wikidataId/Q987/Mean_Rainfall'
+'https://api.datacommons.org/v1/observations/series/wikidataId/Q987/Mean_Rainfall?key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
  

--- a/api/rest/v1/rest_api_template.md
+++ b/api/rest/v1/rest_api_template.md
@@ -25,7 +25,7 @@ GET Request
 {: .api-header}
 
 <div class="api-signature">
-http://api.datacommons.org/v1/end/point/{param1}/{param2}
+http://api.datacommons.org/v1/end/point/{param1}/{param2}?key={api_key}
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -42,6 +42,7 @@ http://api.datacommons.org/v1/end/point/{param1}/{param2}
 
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | query <br /> <optional-tag>Optional</optional-tag> | type | description of query here |
 {: .doc-table }
 
@@ -75,7 +76,7 @@ Request:
 {: .example-box-title}
 ```bash
   $ curl --request GET --url \
-  'https://api.datacommons.org/v1/end/point/param1/param2?query=value'
+  'https://api.datacommons.org/v1/end/point/param1/param2?query=value&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
 

--- a/api/rest/v1/rest_api_template.md
+++ b/api/rest/v1/rest_api_template.md
@@ -76,7 +76,7 @@ Request:
 {: .example-box-title}
 ```bash
   $ curl --request GET --url \
-  'https://api.datacommons.org/v1/end/point/param1/param2?query=value&key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+  'https://api.datacommons.org/v1/end/point/param1/param2?query=value&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
 

--- a/api/rest/v1/rest_bulk_api_template.md
+++ b/api/rest/v1/rest_bulk_api_template.md
@@ -27,12 +27,15 @@ Longer details if necessary can go in a short paragraph here. This is where to d
 </div> 
 
 <div id="GET-request" class="api-tabcontent api-signature">
-https://api.datacommons.org/v1/bulk/end/point?query={value}&query={value}
+https://api.datacommons.org/v1/bulk/end/point?query={value}&query={value}&key={your_api_key}
 </div>
 
 <div id="POST-request" class="api-tabcontent api-signature">
 URL:
 https://api.datacommons.org/v1/bulk/end/point
+
+Header:
+key: {your_api_key}
 
 JSON Data:
 {
@@ -68,6 +71,7 @@ JSON Data:
 
 | Name                                               | Type | Description               |
 | -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | query <br /> <optional-tag>Optional</optional-tag> | type | description of query here |
 {: .doc-table }
  
@@ -136,7 +140,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/end/point/'
+'https://api.datacommons.org/v1/bulk/end/point?key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
 ```
 {: .example-box-content .scroll}
  
@@ -151,7 +155,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/end/point \
---header 'content-type: application/json' \
+--header 'key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/rest_bulk_api_template.md
+++ b/api/rest/v1/rest_bulk_api_template.md
@@ -35,7 +35,7 @@ URL:
 https://api.datacommons.org/v1/bulk/end/point
 
 Header:
-key: {your_api_key}
+X-Api-Key: {your_api_key}
 
 JSON Data:
 {
@@ -155,7 +155,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/end/point \
---header 'key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
+--header 'X-API-Key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/rest_bulk_api_template.md
+++ b/api/rest/v1/rest_bulk_api_template.md
@@ -35,7 +35,7 @@ URL:
 https://api.datacommons.org/v1/bulk/end/point
 
 Header:
-X-Api-Key: {your_api_key}
+X-API-Key: {your_api_key}
 
 JSON Data:
 {
@@ -140,7 +140,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/end/point?key=AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo'
+'https://api.datacommons.org/v1/bulk/end/point?key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
  
@@ -155,7 +155,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/end/point \
---header 'X-API-Key: AIzaSyCnBLQK-ODEklqXc99yo7G8vKmoBYW_2wo' \
+--header 'key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}

--- a/api/rest/v1/rest_bulk_api_template.md
+++ b/api/rest/v1/rest_bulk_api_template.md
@@ -155,7 +155,7 @@ Request:
 ```bash
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/end/point \
---header 'key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
 --data '{"entities":["geoId/06", "geoId/48"], "variables":["Count_Person_Male", "Count_Person_Female"], "date":"2019"}'
 ```
 {: .example-box-content .scroll}

--- a/assets/js/syntax_highlighting.js
+++ b/assets/js/syntax_highlighting.js
@@ -3,8 +3,8 @@
  * documentation pages.
  *
  * Highlights text with the class "api-signature"
- * Selects all instances of POST, GET, DELETE, PUT, PATCH, 'URL:' and 'JSON
- * Data:' and applies the "keyword" class to it. Selects all instances of
+ * Selects all instances of POST, GET, DELETE, PUT, PATCH, 'URL:', 'JSON
+ * Data:' and 'Header:' and applies the "keyword" class to it. Selects all instances of
  * '[in|out]' and all words surrounded by {} and applies the "param" class to
  * it.
  *
@@ -15,7 +15,7 @@
  */
 
 function customRESTSyntaxHighlighting(className) {
-  const keyword_regex = /(GET|POST|HEAD|DELETE|PUT|PATCH|URL:|JSON Data:)/g;
+  const keyword_regex = /(GET|POST|HEAD|DELETE|PUT|PATCH|URL:|JSON Data:|Header:)/g;
   const param_regex = /{\w+}/g;
   const in_out_regex = /\[in\|out\]/g;
 


### PR DESCRIPTION
This  PR adds documentation for API key enforcement. More specifically, this includes:
* Updating getting started guide with instructions on how to acquire and use API keys
* Updating endpoint pages to include keys as a parameter
* Include the demo key in endpoint page examples.

A demo of the site with these changes can be found at [https://juliawu.github.io/datacommons-docsite/api/rest/v1/getting_started](https://juliawu.github.io/datacommons-docsite/api/rest/v1/getting_started)