### PR TITLE
[v1 API Docs] Add */info/variable pages (unpublished)

### DIFF
--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -8,13 +8,16 @@ published: false
 permalink: /api/rest/v1/bulk/info/variable
 ---
 
-
-
 ## /v1/bulk/info/variable
 
-Get basic information about multiple [variables](/api/rest/v1/getting_started#variable).
+Get basic information about multiple
+[variables](/api/rest/v1/getting_started#variable).
 
-This API returns basic information on multiple variables, given each of their [DCIDs](/api/rest/v1/getting_started#dcid). The information is provided per variable, and includes the number of entities with data on each variable, the minimum and maximum values observed, and the name and DCID of the top 3 entities with highest observed values for each variable.
+This API returns basic information on multiple variables, given each of their
+[DCIDs](/api/rest/v1/getting_started#dcid). The information is provided per
+variable, and includes the number of entities with data on each variable, the
+minimum and maximum values observed, and the name and DCID of the top 3 entities
+with highest observed values for each variable.
 
 <div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>Tip:</b><br />
@@ -27,8 +30,6 @@ This API returns basic information on multiple variables, given each of their [D
     For querying a single variable and a simpler output, see the [simple version](/api/rest/v1/info/variable) of this endpoint.
 </div>
 
-
-
 ## Request
 
 <div class="api-tab">
@@ -38,12 +39,11 @@ This API returns basic information on multiple variables, given each of their [D
   <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
     POST Request
   </button>
-</div> 
+</div>
 
 <div id="GET-request" class="api-tabcontent api-signature"><div class="scroll">
 https://api.datacommons.org/v1/bulk/info/variable?entities={variable_dcid_1}&entities={variable_dcid_2}&key={your_api_key}
 </div></div>
-
 
 <div id="POST-request" class="api-tabcontent api-signature"><div class="scroll">
 URL:
@@ -54,17 +54,18 @@ X-API-Key: {your_api_key}
 
 JSON Data:
 {
-  "entities": [
-    "{variable_dcid_1}",
-    "{variable_dcid_2}",
-    ...
-  ]
+  "entities":
+    [
+      "{variable_dcid_1}",
+      "{variable_dcid_2}",
+      ...
+    ]
 }
+
 </div></div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
 <script src="/assets/js/api-doc-tabs.js"></script>
-
 
 ### Path Parameters
 
@@ -72,10 +73,10 @@ This endpoint has no path parameters.
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag> | string | Your API Key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/api/rest/v1/getting_started#dcid) of the variables to query information for. |
+| Name                                                  | Type   | Description                                                                                                                                                     |
+| ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag>      | string | Your API Key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/api/rest/v1/getting_started#dcid) of the variables to query information for.                                                                           |
 {: .doc-table }
 
 ## Response
@@ -168,17 +169,18 @@ The response looks like:
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string | [DCID](/api/rest/v1/getting_started#dcid) of the variable queried. |
-| info     | object | Information about the variable queried. Includes maximum and minimum values, and number of places with data on the variable queried, grouped by place type (country-level, state-level, city-level, etc. statistics are grouped together). Also includes information about the provenance of data for the variable queried. |
+| Name   | Type   | Description                                                                                                                                                                                                                                                                                                                 |
+| ------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| entity | string | [DCID](/api/rest/v1/getting_started#dcid) of the variable queried.                                                                                                                                                                                                                                                          |
+| info   | object | Information about the variable queried. Includes maximum and minimum values, and number of places with data on the variable queried, grouped by place type (country-level, state-level, city-level, etc. statistics are grouped together). Also includes information about the provenance of data for the variable queried. |
 {: .doc-table}
 
 ## Examples
 
 ### Example 1: Get information for multiple variables
 
-Get information on the variables for number of farms (DCID: `Count_Farm`) and number of teachers (DCID: `Count_Teacher`).
+Get information on the variables for number of farms (DCID: `Count_Farm`) and
+number of teachers (DCID: `Count_Teacher`).
 
 <div>
 {% tabs example1 %}
@@ -189,16 +191,15 @@ Request:
 {: .example-box-title}
 
 ```bash
-$ curl --request GET --url \ 
+$ curl --request GET --url \
 'https://api.datacommons.org/v1/bulk/info/variable?entities=Count_Farm&entities=Count_Teacher&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
- 
+
 {% tab example1 POST Request %}
- 
+
 Request:
 {: .example-box-title}
 
@@ -209,28 +210,25 @@ $ curl --request POST \
 --data '{"entities":["Count_Farm", "Count_Teacher"]}'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
+
 {% endtabs %}
+
 </div>
 
 Response:
 {: .example-box-title}
+
 ```json
 {
-  "data":
-  [
+  "data": [
     {
       "entity": "Count_Farm",
-      "info":
-      {
-        "placeTypeSummary":
-        {
-          "County":
-          {
-            "topPlaces":
-            [
+      "info": {
+        "placeTypeSummary": {
+          "County": {
+            "topPlaces": [
               {
                 "dcid": "geoId/06037",
                 "name": "Los Angeles County"
@@ -248,10 +246,8 @@ Response:
             "minValue": 2,
             "maxValue": 5551
           },
-          "Country":
-          {
-            "topPlaces":
-            [
+          "Country": {
+            "topPlaces": [
               {
                 "dcid": "country/USA",
                 "name": "United States"
@@ -261,10 +257,8 @@ Response:
             "minValue": 2042220,
             "maxValue": 2042220
           },
-          "State":
-          {
-            "topPlaces":
-            [
+          "State": {
+            "topPlaces": [
               {
                 "dcid": "geoId/06",
                 "name": "California"
@@ -283,27 +277,20 @@ Response:
             "maxValue": 248416
           }
         },
-        "provenanceSummary":
-        {
-          "dc/m02b5p":
-          {
+        "provenanceSummary": {
+          "dc/m02b5p": {
             "importName": "USDA_AgricultureCensus",
             "releaseFrequency": "P5Y",
-            "seriesSummary":
-            [
+            "seriesSummary": [
               {
-                "seriesKey":
-                {
+                "seriesKey": {
                   "observationPeriod": "P5Y"
                 },
                 "earliestDate": "2017",
                 "latestDate": "2017",
-                "placeTypeSummary":
-                {
-                  "Country":
-                  {
-                    "topPlaces":
-                    [
+                "placeTypeSummary": {
+                  "Country": {
+                    "topPlaces": [
                       {
                         "dcid": "country/USA",
                         "name": "United States"
@@ -313,10 +300,8 @@ Response:
                     "minValue": 2042220,
                     "maxValue": 2042220
                   },
-                  "State":
-                  {
-                    "topPlaces":
-                    [
+                  "State": {
+                    "topPlaces": [
                       {
                         "dcid": "geoId/06",
                         "name": "California"
@@ -334,10 +319,8 @@ Response:
                     "minValue": 990,
                     "maxValue": 248416
                   },
-                  "County":
-                  {
-                    "topPlaces":
-                    [
+                  "County": {
+                    "topPlaces": [
                       {
                         "dcid": "geoId/06037",
                         "name": "Los Angeles County"
@@ -370,14 +353,10 @@ Response:
     },
     {
       "entity": "Count_Teacher",
-      "info":
-      {
-        "placeTypeSummary":
-        {
-          "SchoolDistrict":
-          {
-            "topPlaces":
-            [
+      "info": {
+        "placeTypeSummary": {
+          "SchoolDistrict": {
+            "topPlaces": [
               {
                 "dcid": "geoId/sch3620580",
                 "name": "New York City Department Of Education"
@@ -394,10 +373,8 @@ Response:
             "placeCount": 18952,
             "maxValue": 28769.06
           },
-          "School":
-          {
-            "topPlaces":
-            [
+          "School": {
+            "topPlaces": [
               {
                 "dcid": "nces/568025400549"
               },
@@ -414,25 +391,18 @@ Response:
             "maxValue": 1702
           }
         },
-        "provenanceSummary":
-        {
-          "dc/mzy8we":
-          {
+        "provenanceSummary": {
+          "dc/mzy8we": {
             "importName": "K12",
             "releaseFrequency": "P1Y",
-            "seriesSummary":
-            [
+            "seriesSummary": [
               {
-                "seriesKey":
-                {},
+                "seriesKey": {},
                 "earliestDate": "2011",
                 "latestDate": "2016",
-                "placeTypeSummary":
-                {
-                  "SchoolDistrict":
-                  {
-                    "topPlaces":
-                    [
+                "placeTypeSummary": {
+                  "SchoolDistrict": {
+                    "topPlaces": [
                       {
                         "dcid": "geoId/sch3620580",
                         "name": "New York City Department Of Education"
@@ -449,10 +419,8 @@ Response:
                     "placeCount": 18952,
                     "maxValue": 28769.06
                   },
-                  "School":
-                  {
-                    "topPlaces":
-                    [
+                  "School": {
+                    "topPlaces": [
                       {
                         "dcid": "nces/568025400549"
                       },

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -32,8 +32,12 @@ This API returns basic information on multiple variables, given each of their [D
 ## Request
 
 <div class="api-tab">
-  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">GET Request</button>
-  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">POST Request</button>
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">
+    GET Request
+  </button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
+    POST Request
+  </button>
 </div> 
 
 <div id="GET-request" class="api-tabcontent api-signature"><div class="scroll">

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Info on a variable
+title: Info of a variable
 nav_exclude: true
 parent: v1 REST
 grand_parent: API
@@ -14,7 +14,7 @@ permalink: /api/rest/v1/bulk/info/variable
 
 Get basic information about multiple [variables](/api/rest/v1/getting_started#variable).
 
-This API returns basic information on multiple variables, given each of their [DCIDs](/api/rest/v1/getting_started#dcid). The information is provided per variable, and includes the number of places with data on each variable, the minimum and maximum values observed, and the name and DCID of the top 3 entities with highest observed values for each variable.
+This API returns basic information on multiple variables, given each of their [DCIDs](/api/rest/v1/getting_started#dcid). The information is provided per variable, and includes the number of entities with data on each variable, the minimum and maximum values observed, and the name and DCID of the top 3 entities with highest observed values for each variable.
 
 <div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>Tip:</b><br />
@@ -113,47 +113,49 @@ The response looks like:
             "minValue": 1,
             "maxValue": 12345
           }, ...
-        "provenanceSummary":
-        {
-          "DCID":
+          "provenanceSummary":
           {
-            "importName": "Import_Name",
-            "releaseFrequency": "P<N>Y",
-            "seriesSummary":
-            [
-              {
-                "seriesKey":
+            "DCID":
+            {
+              "importName": "Import_Name",
+              "releaseFrequency": "P<N>Y",
+              "seriesSummary":
+              [
                 {
-                  "observationPeriod": "P<N>Y"
-                },
-                "earliestDate": "YYYY-MM-DD",
-                "latestDate": "YYYY-MM-DD",
-                "placeTypeSummary":
-                {
-                  "Country/State/City/Etc":
+                  "seriesKey":
                   {
-                    "topPlaces":
-                    [
-                      {
-                        "dcid": "Place DCID",
-                        "name": "Place Name"
-                      }
-                    ],
-                    "placeCount": 123,
+                    "observationPeriod": "P<N>Y"
+                  },
+                  "earliestDate": "YYYY-MM-DD",
+                  "latestDate": "YYYY-MM-DD",
+                  "placeTypeSummary":
+                  {
+                    "Country/State/City/Etc":
+                    {
+                      "topPlaces":
+                      [
+                        {
+                          "dcid": "Place DCID",
+                          "name": "Place Name"
+                        }
+                      ],
+                      "placeCount": 123,
+                      "minValue": 1,
+                      "maxValue": 123456
+                    }, ...
                     "minValue": 1,
-                    "maxValue": 123456
-                  }, ...
-                "minValue": 1,
-                "maxValue": 123456,
-                "observationCount": 123,
-                "timeSeriesCount": 123
-              }, ...
-            ],
-            "observationCount": 123,
-            "timeSeriesCount": 123
+                    "maxValue": 123456,
+                    "observationCount": 123,
+                    "timeSeriesCount": 123
+                  }
+                }, ...
+              ],
+              "observationCount": 123,
+              "timeSeriesCount": 123
+            }
           }
         }
-      }
+      },
     },
     {
       "entity": "Variable_2_DCID",

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -1,0 +1,480 @@
+---
+layout: default
+title: Info on a variable
+nav_exclude: true
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/bulk/info/variable
+---
+
+
+
+## /v1/bulk/info/variable
+
+Get basic information about multiple [variables](/api/rest/v1/getting_started#variable).
+
+This API returns basic information on multiple variables, given each of their [DCIDs](/api/rest/v1/getting_started#dcid). The information is provided per variable, and includes the number of places with data on each variable, the minimum and maximum values observed, and the name and DCID of the top 3 entities with highest observed values for each variable.
+
+<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>Tip:</b><br />
+    To explore variables available in the Data Commons knowledge graph, take a look at the [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
+</div>
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    To get information on a place instead of a variable, see [/v1/bulk/info/place](/api/rest/v1/info/place).<br />
+    For querying a single variable and a simpler output, see the [simple version](/api/rest/v1/info/variable) of this endpoint.
+</div>
+
+
+
+## Request
+
+<div class="api-tab">
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">GET Request</button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">POST Request</button>
+</div> 
+
+<div id="GET-request" class="api-tabcontent api-signature"><div class="scroll">
+https://api.datacommons.org/v1/bulk/info/variable?entities={variable_dcid_1}&entities={variable_dcid_2}&key={your_api_key}
+</div></div>
+
+
+<div id="POST-request" class="api-tabcontent api-signature"><div class="scroll">
+URL:
+https://api.datacommons.org/v1/bulk/info/variable
+
+Header:
+X-API-Key: {your_api_key}
+
+JSON Data:
+{
+  "entities": [
+    "{variable_dcid_1}",
+    "{variable_dcid_2}",
+    ...
+  ]
+}
+</div></div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+<script src="/assets/js/api-doc-tabs.js"></script>
+
+
+### Path Parameters
+
+This endpoint has no path parameters.
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag> | string | Your API Key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/api/rest/v1/getting_started#dcid) of the variables to query information for. |
+{: .doc-table }
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "Variable_1_DCID",
+      "info":
+      {
+        "placeTypeSummary":
+        {
+          "County/City/State/Etc":
+          {
+            "topPlaces":
+            [
+              {
+                "dcid": "Place DCID",
+                "name": "Place Name"
+              },
+              {
+                "dcid": "Place DCID",
+                "name": "Place Name"
+              },
+              {
+                "dcid": "Place DCID",
+                "name": "Place Name"
+              }
+            ],
+            "placeCount": 123,
+            "minValue": 1,
+            "maxValue": 12345
+          }, ...
+        "provenanceSummary":
+        {
+          "DCID":
+          {
+            "importName": "Import_Name",
+            "releaseFrequency": "P<N>Y",
+            "seriesSummary":
+            [
+              {
+                "seriesKey":
+                {
+                  "observationPeriod": "P<N>Y"
+                },
+                "earliestDate": "YYYY-MM-DD",
+                "latestDate": "YYYY-MM-DD",
+                "placeTypeSummary":
+                {
+                  "Country/State/City/Etc":
+                  {
+                    "topPlaces":
+                    [
+                      {
+                        "dcid": "Place DCID",
+                        "name": "Place Name"
+                      }
+                    ],
+                    "placeCount": 123,
+                    "minValue": 1,
+                    "maxValue": 123456
+                  }, ...
+                "minValue": 1,
+                "maxValue": 123456,
+                "observationCount": 123,
+                "timeSeriesCount": 123
+              }, ...
+            ],
+            "observationCount": 123,
+            "timeSeriesCount": 123
+          }
+        }
+      }
+    },
+    {
+      "entity": "Variable_2_DCID",
+      "info": {...}
+    }, ...
+  ]
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string | [DCID](/api/rest/v1/getting_started#dcid) of the variable queried. |
+| info     | object | Information about the variable queried. Includes maximum and minimum values, and number of places with data on the variable queried, grouped by place type (country-level, state-level, city-level, etc. statistics are grouped together). Also includes information about the provenance of data for the variable queried. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Get information for multiple variables
+
+Get information on the variables for number of farms (DCID: `Count_Farm`) and number of teachers (DCID: `Count_Teacher`).
+
+<div>
+{% tabs example1 %}
+ 
+{% tab example1 GET Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request GET --url \ 
+'https://api.datacommons.org/v1/bulk/info/variable?entities=Count_Farm&entities=Count_Teacher&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+ 
+{% tab example1 POST Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request POST \
+--url https://api.datacommons.org/v1/bulk/info/variable \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities":["Count_Farm", "Count_Teacher"]}'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+{% endtabs %}
+</div>
+
+Response:
+{: .example-box-title}
+```json
+{
+  "data":
+  [
+    {
+      "entity": "Count_Farm",
+      "info":
+      {
+        "placeTypeSummary":
+        {
+          "County":
+          {
+            "topPlaces":
+            [
+              {
+                "dcid": "geoId/06037",
+                "name": "Los Angeles County"
+              },
+              {
+                "dcid": "geoId/17031",
+                "name": "Cook County"
+              },
+              {
+                "dcid": "geoId/48201",
+                "name": "Harris County"
+              }
+            ],
+            "placeCount": 3076,
+            "minValue": 2,
+            "maxValue": 5551
+          },
+          "Country":
+          {
+            "topPlaces":
+            [
+              {
+                "dcid": "country/USA",
+                "name": "United States"
+              }
+            ],
+            "placeCount": 1,
+            "minValue": 2042220,
+            "maxValue": 2042220
+          },
+          "State":
+          {
+            "topPlaces":
+            [
+              {
+                "dcid": "geoId/06",
+                "name": "California"
+              },
+              {
+                "dcid": "geoId/48",
+                "name": "Texas"
+              },
+              {
+                "dcid": "geoId/12",
+                "name": "Florida"
+              }
+            ],
+            "placeCount": 50,
+            "minValue": 990,
+            "maxValue": 248416
+          }
+        },
+        "provenanceSummary":
+        {
+          "dc/m02b5p":
+          {
+            "importName": "USDA_AgricultureCensus",
+            "releaseFrequency": "P5Y",
+            "seriesSummary":
+            [
+              {
+                "seriesKey":
+                {
+                  "observationPeriod": "P5Y"
+                },
+                "earliestDate": "2017",
+                "latestDate": "2017",
+                "placeTypeSummary":
+                {
+                  "Country":
+                  {
+                    "topPlaces":
+                    [
+                      {
+                        "dcid": "country/USA",
+                        "name": "United States"
+                      }
+                    ],
+                    "placeCount": 1,
+                    "minValue": 2042220,
+                    "maxValue": 2042220
+                  },
+                  "State":
+                  {
+                    "topPlaces":
+                    [
+                      {
+                        "dcid": "geoId/06",
+                        "name": "California"
+                      },
+                      {
+                        "dcid": "geoId/48",
+                        "name": "Texas"
+                      },
+                      {
+                        "dcid": "geoId/12",
+                        "name": "Florida"
+                      }
+                    ],
+                    "placeCount": 50,
+                    "minValue": 990,
+                    "maxValue": 248416
+                  },
+                  "County":
+                  {
+                    "topPlaces":
+                    [
+                      {
+                        "dcid": "geoId/06037",
+                        "name": "Los Angeles County"
+                      },
+                      {
+                        "dcid": "geoId/17031",
+                        "name": "Cook County"
+                      },
+                      {
+                        "dcid": "geoId/48201",
+                        "name": "Harris County"
+                      }
+                    ],
+                    "placeCount": 3076,
+                    "minValue": 2,
+                    "maxValue": 5551
+                  }
+                },
+                "minValue": 2,
+                "maxValue": 2042220,
+                "observationCount": 3127,
+                "timeSeriesCount": 3127
+              }
+            ],
+            "observationCount": 3127,
+            "timeSeriesCount": 3127
+          }
+        }
+      }
+    },
+    {
+      "entity": "Count_Teacher",
+      "info":
+      {
+        "placeTypeSummary":
+        {
+          "SchoolDistrict":
+          {
+            "topPlaces":
+            [
+              {
+                "dcid": "geoId/sch3620580",
+                "name": "New York City Department Of Education"
+              },
+              {
+                "dcid": "geoId/sch0622710",
+                "name": "Los Angeles Unified"
+              },
+              {
+                "dcid": "geoId/sch1709930",
+                "name": "Chicago Public School District 299"
+              }
+            ],
+            "placeCount": 18952,
+            "maxValue": 28769.06
+          },
+          "School":
+          {
+            "topPlaces":
+            [
+              {
+                "dcid": "nces/568025400549"
+              },
+              {
+                "dcid": "nces/568025300548",
+                "name": "Wyoming Behavioral Institute"
+              },
+              {
+                "dcid": "nces/568025200350",
+                "name": "Youth Emergency Services Inc."
+              }
+            ],
+            "placeCount": 102977,
+            "maxValue": 1702
+          }
+        },
+        "provenanceSummary":
+        {
+          "dc/mzy8we":
+          {
+            "importName": "K12",
+            "releaseFrequency": "P1Y",
+            "seriesSummary":
+            [
+              {
+                "seriesKey":
+                {},
+                "earliestDate": "2011",
+                "latestDate": "2016",
+                "placeTypeSummary":
+                {
+                  "SchoolDistrict":
+                  {
+                    "topPlaces":
+                    [
+                      {
+                        "dcid": "geoId/sch3620580",
+                        "name": "New York City Department Of Education"
+                      },
+                      {
+                        "dcid": "geoId/sch0622710",
+                        "name": "Los Angeles Unified"
+                      },
+                      {
+                        "dcid": "geoId/sch1709930",
+                        "name": "Chicago Public School District 299"
+                      }
+                    ],
+                    "placeCount": 18952,
+                    "maxValue": 28769.06
+                  },
+                  "School":
+                  {
+                    "topPlaces":
+                    [
+                      {
+                        "dcid": "nces/568025400549"
+                      },
+                      {
+                        "dcid": "nces/568025300548",
+                        "name": "Wyoming Behavioral Institute"
+                      },
+                      {
+                        "dcid": "nces/568025200350",
+                        "name": "Youth Emergency Services Inc."
+                      }
+                    ],
+                    "placeCount": 102977,
+                    "maxValue": 1702
+                  }
+                },
+                "maxValue": 28769.06,
+                "observationCount": 618283,
+                "timeSeriesCount": 121929
+              }
+            ],
+            "observationCount": 618283,
+            "timeSeriesCount": 121929
+          }
+        }
+      }
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}

--- a/api/rest/v1/info_variable.md
+++ b/api/rest/v1/info_variable.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Info on a variable
+title: Info of a variable
 nav_order: 2
 parent: v1 REST
 grand_parent: API
@@ -14,7 +14,7 @@ permalink: /api/rest/v1/info/variable
  
 Get basic information about a [variable](/api/rest/v1/getting_started#variable).
  
-This API returns basic information on a variable, given the variable's [DCID](/api/rest/v1/getting_started#dcid). The information provided includes the number of places that have data for the variable, the minimum and maximum value observed, and the name and DCID of the top 3 entities with highest observed values for that variable. The information is grouped by place type (country, state, county, etc.).
+This API returns basic information on a variable, given the variable's [DCID](/api/rest/v1/getting_started#dcid). The information provided includes the number of entities that have data for the variable, the minimum and maximum value observed, and the name and DCID of the top 3 entities with highest observed values for that variable. The information is grouped by place type (country, state, county, etc.).
  
 <div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
@@ -215,6 +215,3 @@ Response:
 }
 ```
 {: .example-box-content .scroll}
- 
- 
-

--- a/api/rest/v1/info_variable.md
+++ b/api/rest/v1/info_variable.md
@@ -1,0 +1,220 @@
+---
+layout: default
+title: Info on a variable
+nav_order: 2
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/info/variable
+---
+ 
+ 
+ 
+## /v1/info/variable
+ 
+Get basic information about a [variable](/api/rest/v1/getting_started#variable).
+ 
+This API returns basic information on a variable, given the variable's [DCID](/api/rest/v1/getting_started#dcid). The information provided includes the number of places that have data for the variable, the minimum and maximum value observed, and the name and DCID of the top 3 entities with highest observed values for that variable. The information is grouped by place type (country, state, county, etc.).
+ 
+<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+   <span class="material-icons md-16">info </span><b>Tip:</b><br />
+   To explore variables available in the Data Commons knowledge graph, take a look at the [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
+</div>
+ 
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+   <span class="material-icons md-16">info </span><b>See Also:</b><br />
+   To get information on a place instead of a variable, see [/v1/info/place](/api/rest/v1/info/place).<br />
+   For querying multiple variables, see the [bulk version](/api/rest/v1/bulk/info/variable) of this endpoint.
+</div>
+ 
+ 
+ 
+## Request
+GET Request
+{: .api-header}
+
+<div class="api-signature">
+https://api.datacommons.org/v1/info/variable/{VARIABLE_DCID}?key={your_api_key}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+
+ 
+### Path Parameters
+ 
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| VARIABLE_DCID <br /> <required-tag>Required</required-tag> | [DCID](/api/rest/v1/getting_started#dcid) of the variable to query information for. |
+{: .doc-table}
+ 
+### Query Parameters
+ 
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag> | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+{: .doc-table }
+ 
+## Response
+ 
+The response looks like:
+ 
+```json
+{
+  "entity": "dcid",
+  "info": {
+    "placeTypeSummary": {
+      "Country/State/City/Etc": {
+        "topPlaces": [{ "dcid": "dcid", "name": "Place Name" }],
+        "placeCount": 123,
+        "minValue": 123456,
+        "maxValue": 123456
+      }, ...
+    },
+    "provenanceSummary": {
+      "provenance_dcid": {
+        "importName": "Import_Name",
+        "releaseFrequency": "P<N>Y",
+        "seriesSummary": [
+          {
+            "seriesKey": { "observationPeriod": "P<N>Y" },
+            "earliestDate": "YYYY-MM-DD",
+            "latestDate": "YYYY-MM-DD",
+            "placeTypeSummary": {
+              "County/Country/State/Etc": {
+                "topPlaces": [
+                  { "dcid": "dcid", "name": "Place Name" },
+                  { "dcid": "dcid", "name": "Place Name" },
+                  { "dcid": "dcid", "name": "Plance Name" }
+                ],
+                "placeCount": 123,
+                "minValue": 12,
+                "maxValue": 123456
+              }, ...
+            },
+            "minValue": 12,
+            "maxValue": 123456,
+            "observationCount": 123,
+            "timeSeriesCount": 123
+          }
+        ],
+        "observationCount": 1234,
+        "timeSeriesCount": 1234
+      }
+    }
+  }
+}
+```
+{: .response-signature .scroll}
+ 
+### Response fields
+ 
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string | [DCID](/api/rest/v1/getting_started#dcid) of the variable queried. |
+| info     | object | Information about the variable queried. Includes maximum and minimum values, and number of places with data on the variable queried, grouped by place type (country-level, state-level, city-level, etc. statistics are grouped together). Also includes information about the provenance of data for the variable queried. |
+{: .doc-table}
+ 
+## Examples
+ 
+### Example 1: Get information on a single variable
+ 
+Get basic information about the variable for number of farms (DCID: `Count_Farm`). 
+ 
+Request:
+{: .example-box-title}
+```bash
+$ curl --request GET --url \
+'https://api.datacommons.org/v1/info/variable/Count_Farm?key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+ 
+Response:
+{: .example-box-title}
+```json
+{
+  "entity": "Count_Farm",
+  "info": {
+    "placeTypeSummary": {
+      "Country": {
+        "topPlaces": [{ "dcid": "country/USA", "name": "United States" }],
+        "placeCount": 1,
+        "minValue": 123456,
+        "maxValue": 2042220
+      },
+      "State": {
+        "topPlaces": [
+          { "dcid": "geoId/06", "name": "California" },
+          { "dcid": "geoId/48", "name": "Texas" },
+          { "dcid": "geoId/12", "name": "Florida" }
+        ],
+        "placeCount": 50,
+        "minValue": 990,
+        "maxValue": 248416
+      },
+      "County": {
+        "topPlaces": [
+          { "dcid": "geoId/06037", "name": "Los Angeles County" },
+          { "dcid": "geoId/17031", "name": "Cook County" },
+          { "dcid": "geoId/48201", "name": "Harris County" }
+        ],
+        "placeCount": 3076,
+        "minValue": 2,
+        "maxValue": 5551
+      }
+    },
+    "provenanceSummary": {
+      "dc/m02b5p": {
+        "importName": "USDA_AgricultureCensus",
+        "releaseFrequency": "P5Y",
+        "seriesSummary": [
+          {
+            "seriesKey": { "observationPeriod": "P5Y" },
+            "earliestDate": "2017",
+            "latestDate": "2017",
+            "placeTypeSummary": {
+              "County": {
+                "topPlaces": [
+                  { "dcid": "geoId/06037", "name": "Los Angeles County" },
+                  { "dcid": "geoId/17031", "name": "Cook County" },
+                  { "dcid": "geoId/48201", "name": "Harris County" }
+                ],
+                "placeCount": 3076,
+                "minValue": 2,
+                "maxValue": 5551
+              },
+              "Country": {
+                "topPlaces": [
+                  { "dcid": "country/USA", "name": "United States" }
+                ],
+                "placeCount": 1,
+                "minValue": 2042220,
+                "maxValue": 2042220
+              },
+              "State": {
+                "topPlaces": [
+                  { "dcid": "geoId/06", "name": "California" },
+                  { "dcid": "geoId/48", "name": "Texas" },
+                  { "dcid": "geoId/12", "name": "Florida" }
+                ],
+                "placeCount": 50,
+                "minValue": 990,
+                "maxValue": 248416
+              }
+            },
+            "minValue": 2,
+            "maxValue": 2042220,
+            "observationCount": 3127,
+            "timeSeriesCount": 3127
+          }
+        ],
+        "observationCount": 3127,
+        "timeSeriesCount": 3127
+      }
+    }
+  }
+}
+```
+{: .example-box-content .scroll}
+ 
+ 
+

--- a/api/rest/v1/info_variable.md
+++ b/api/rest/v1/info_variable.md
@@ -7,15 +7,18 @@ grand_parent: API
 published: false
 permalink: /api/rest/v1/info/variable
 ---
- 
- 
- 
+
 ## /v1/info/variable
- 
+
 Get basic information about a [variable](/api/rest/v1/getting_started#variable).
- 
-This API returns basic information on a variable, given the variable's [DCID](/api/rest/v1/getting_started#dcid). The information provided includes the number of entities that have data for the variable, the minimum and maximum value observed, and the name and DCID of the top 3 entities with highest observed values for that variable. The information is grouped by place type (country, state, county, etc.).
- 
+
+This API returns basic information on a variable, given the variable's
+[DCID](/api/rest/v1/getting_started#dcid). The information provided includes the
+number of entities that have data for the variable, the minimum and maximum
+value observed, and the name and DCID of the top 3 entities with highest
+observed values for that variable. The information is grouped by place type
+(country, state, county, etc.).
+
 <div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
    To explore variables available in the Data Commons knowledge graph, take a look at the [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
@@ -26,10 +29,9 @@ This API returns basic information on a variable, given the variable's [DCID](/a
    To get information on a place instead of a variable, see [/v1/info/place](/api/rest/v1/info/place).<br />
    For querying multiple variables, see the [bulk version](/api/rest/v1/bulk/info/variable) of this endpoint.
 </div>
- 
- 
- 
+
 ## Request
+
 GET Request
 {: .api-header}
 
@@ -39,25 +41,24 @@ https://api.datacommons.org/v1/info/variable/{VARIABLE_DCID}?key={your_api_key}
 
 <script src="/assets/js/syntax_highlighting.js"></script>
 
- 
 ### Path Parameters
- 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
+
+| Name                                                       | Description                                                                         |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | VARIABLE_DCID <br /> <required-tag>Required</required-tag> | [DCID](/api/rest/v1/getting_started#dcid) of the variable to query information for. |
 {: .doc-table}
- 
+
 ### Query Parameters
- 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
+
+| Name                                             | Type   | Description                                                                                                                                                     |
+| ------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | key <br /> <required-tag>Required</required-tag> | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 {: .doc-table }
- 
+
 ## Response
- 
+
 The response looks like:
- 
+
 ```json
 {
   "entity": "dcid",
@@ -105,31 +106,34 @@ The response looks like:
 }
 ```
 {: .response-signature .scroll}
- 
+
 ### Response fields
- 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string | [DCID](/api/rest/v1/getting_started#dcid) of the variable queried. |
-| info     | object | Information about the variable queried. Includes maximum and minimum values, and number of places with data on the variable queried, grouped by place type (country-level, state-level, city-level, etc. statistics are grouped together). Also includes information about the provenance of data for the variable queried. |
+
+| Name   | Type   | Description                                                                                                                                                                                                                                                                                                                 |
+| ------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| entity | string | [DCID](/api/rest/v1/getting_started#dcid) of the variable queried.                                                                                                                                                                                                                                                          |
+| info   | object | Information about the variable queried. Includes maximum and minimum values, and number of places with data on the variable queried, grouped by place type (country-level, state-level, city-level, etc. statistics are grouped together). Also includes information about the provenance of data for the variable queried. |
 {: .doc-table}
- 
+
 ## Examples
- 
+
 ### Example 1: Get information on a single variable
- 
-Get basic information about the variable for number of farms (DCID: `Count_Farm`). 
- 
-Request:
+
+Get basic information about the variable for number of farms (DCID:
+`Count_Farm`).
+
+Request: 
 {: .example-box-title}
+
 ```bash
 $ curl --request GET --url \
 'https://api.datacommons.org/v1/info/variable/Count_Farm?key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
- 
+
 Response:
 {: .example-box-title}
+
 ```json
 {
   "entity": "Count_Farm",


### PR DESCRIPTION
This PR adds the documentation pages for:
* [v1/info/variable](https://juliawu.github.io/datacommons-docsite/api/rest/v1/info/variable)
* [v1/bulk/info/variable](https://juliawu.github.io/datacommons-docsite/api/rest/v1/bulk/info/variable)

Pages are still unpublished. Final ordering of sidebar and landing page links will happen in a separate PR once all pages are in, before publishing.