### PR TITLE
[v1 API Docs] Add */properties pages (unpublished)

### DIFF
--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -10,17 +10,21 @@ permalink: /api/rest/v1/bulk/properties
 
 # /v1/bulk/properties
 
-Get all [properties](/glossary.html#property) associated with a specific entity, for multiple entities.
+Get all [properties](/glossary.html#property) associated with a specific node,
+for multiple nodes.
 
-More specifically, this endpoint returns the labels of the edges connected to a specific node in the Data Commons Knowledge Graph. Edges in the graph are directed, so properties can either be labels for edges _towards_ or _away_ from the node. Outgoing edges correspond to properties of the node. Incoming edges denote that the node is the value of this property for some other node.
+More specifically, this endpoint returns the labels of the edges connected to a
+specific node in the Data Commons Knowledge Graph. Edges in the graph are
+directed, so properties can either be labels for edges _towards_ or _away_ from
+the node. Outgoing edges correspond to properties of the node. Incoming edges
+denote that the node is the value of this property for some other node.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To the values of properties, see [/v1/bulk/property/values](/api/rest/v1/bulk/property/values).<br />
     To find connected edges and nodes, see [/v1/bulk/triples](/api/rest/v1/bulk/triples).<br />
-    For querying a single entity with simpler output, see the [simple version](/api/rest/v1/properties) of this endpoint.
+    For querying a single node with simpler output, see the [simple version](/api/rest/v1/properties) of this endpoint.
 </div>
- 
 
 ## Request
 
@@ -31,10 +35,10 @@ More specifically, this endpoint returns the labels of the edges connected to a 
   <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
     POST Request
   </button>
-</div> 
+</div>
 
 <div id="GET-request" class="api-tabcontent api-signature">
-https://api.datacommons.org/v1/bulk/properties/{EDGE_DIRECTION}?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+https://api.datacommons.org/v1/bulk/properties/{EDGE_DIRECTION}?nodes={node_dcid_1}&nodes={node_dcid_2}&key={your_api_key}
 </div>
 
 <div id="POST-request" class="api-tabcontent api-signature">
@@ -46,12 +50,14 @@ X-API-Key: {your_api_key}
 
 JSON Data:
 {
-  "entities": [
+  "nodes":
+  [
     "{value_1}",
     "{value_2}",
     ...
   ]
 }
+
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -59,32 +65,29 @@ JSON Data:
 
 ### Path Parameters
 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns properties represented by edges pointing _toward_ the entity provided. If `out`, returns properties represented by edges pointing _away_ from the entity provided. |
+| Name                                                        | Description                                                                                                                                                                                                                                                      |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns properties represented by edges pointing _toward_ the node provided. If `out`, returns properties represented by edges pointing _away_ from the node provided. |
 {: .doc-table }
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
+| Name                                               | Type   | Description                                                                                                                                                     |
+| -------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the entities to query. |
+| nodes <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the nodes to query.                                                                                                             |
 {: .doc-table }
- 
- 
 
 ## Response
 
- 
 The response looks like:
- 
+
 ```json
 {
   "data":
   [
     {
-      "entity": "entity_1_dcid",
+      "node": "node_1_dcid",
       "properties":
       [
         "property_1",
@@ -93,57 +96,53 @@ The response looks like:
       ]
     },
     {
-      "entity": "entity_2_dcid",
+      "node": "node_2_dcid",
       "properties":
       [
         "property_1",
         "property_2",
         ...
       ]
-      
+
     }, ...
   ]
 }
 ```
 {: .response-signature .scroll}
- 
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
-| properties | list | List of properties connected to the entity queried, for the direction specified in the request. |
+| Name       | Type   | Description                                                                                   |
+| ---------- | ------ | --------------------------------------------------------------------------------------------- |
+| node       | string | [DCID](/glossary.html#dcid) of the node queried.                                              |
+| properties | list   | List of properties connected to the node queried, for the direction specified in the request. |
 {: .doc-table}
- 
 
 ## Examples
 
- 
+### Example 1: Get properties for mulitple nodes.
 
-### Example 1: Get properties describing multiple entities.
-
-Get properties describing the US states of Virgina (DCID: `geoId/51`), Maryland (DCID: `geoId/24`), and Delaware (DCID: `geoId/10`).
+Get properties describing the US states of Virgina (DCID: `geoId/51`), Maryland
+(DCID: `geoId/24`), and Delaware (DCID: `geoId/10`).
 
 <div>
 {% tabs example1 %}
- 
+
 {% tab example1 GET Request %}
- 
+
 Request:
 {: .example-box-title}
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/properties/out?entities=geoId/51&entities=geoId/24&entities=geoId/10&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+'https://api.datacommons.org/v1/bulk/properties/out?nodes=geoId/51&nodes=geoId/24&nodes=geoId/10&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
- 
+
 {% tab example1 POST Request %}
- 
+
 Request:
 {: .example-box-title}
 
@@ -151,13 +150,14 @@ Request:
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/properties/out \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities":["geoId/51", "geoId/24", "geoId/10"]}'
+--data '{"nodes":["geoId/51", "geoId/24", "geoId/10"]}'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
+
 {% endtabs %}
+
 </div>
  
 Response:
@@ -168,164 +168,39 @@ Response:
   "data":
   [
     {
-      "entity": "geoId/51",
+      "node": "geoId/51",
       "properties":
       [
         "administrativeCapital",
         "alternateName",
         "archinformLocationId",
-        "area",
-        "babelnetId",
-        "bbcThingsId",
-        "containedInPlace",
-        "czechNkcrAutId",
-        "encyclopediaBritannicaOnlineId",
-        "encyclopediaLarousseId",
-        "finlandYsoId",
-        "fips104",
-        "fips52AlphaCode",
-        "gacsId",
-        "geoId",
-        "geoJsonCoordinates",
-        "geoJsonCoordinatesDP1",
-        "geoJsonCoordinatesDP2",
-        "geoJsonCoordinatesDP3",
-        "gettyThesaurusOfGeographicNamesId",
-        "gndId",
-        "gnisId",
-        "granEnciclopediaCatalanaId",
-        "greatRussianEncyclopediaOnlineId",
-        "isoCode",
-        "kmlCoordinates",
-        "landArea",
-        "latitude",
-        "libraryOfCongressAuthorityId",
-        "longitude",
-        "musicbrainzAreaId",
-        "name",
-        "nameWithLanguage",
-        "nationalDietLibraryId",
-        "nearbyPlaces",
-        "osmRelationId",
-        "provenance",
-        "quoraTopicId",
-        "ringgoldId",
-        "selibrId",
-        "typeOf",
-        "unitedStatesNationalArchivesIdentifier",
-        "viafId",
-        "waterArea",
+        < ... output truncated for brevity ... >
         "whosOnFirstId",
         "wikidataId",
         "worldcatIdentitiesId"
       ]
     },
     {
-      "entity": "geoId/24",
+      "node": "geoId/24",
       "properties":
       [
         "administrativeCapital",
         "alternateName",
         "archinformLocationId",
-        "area",
-        "babelnetId",
-        "bbcThingsId",
-        "containedInPlace",
-        "czechNkcrAutId",
-        "encyclopediaBritannicaOnlineId",
-        "encyclopediaLarousseId",
-        "finlandYsoId",
-        "fips104",
-        "fips52AlphaCode",
-        "franceNationalLibraryId",
-        "gacsId",
-        "geoId",
-        "geoJsonCoordinates",
-        "geoJsonCoordinatesDP1",
-        "geoJsonCoordinatesDP2",
-        "geoJsonCoordinatesDP3",
-        "gettyThesaurusOfGeographicNamesId",
-        "gndId",
-        "gnisId",
-        "granEnciclopediaCatalanaId",
-        "isoCode",
-        "israelNationalLibraryId",
-        "kmlCoordinates",
-        "landArea",
-        "latitude",
-        "libraryOfCongressAuthorityId",
-        "longitude",
-        "musicbrainzAreaId",
-        "name",
-        "nameWithLanguage",
-        "nationalDietLibraryId",
-        "nearbyPlaces",
-        "osmRelationId",
-        "provenance",
-        "quoraTopicId",
-        "ringgoldId",
-        "selibrId",
-        "spainNationalLibraryId",
-        "swedishNationalEncyclopediaId",
-        "typeOf",
-        "unitedStatesNationalArchivesIdentifier",
-        "viafId",
-        "waterArea",
+        < ... output truncated for brevity ... >
         "whosOnFirstId",
         "wikidataId",
         "worldcatIdentitiesId"
       ]
     },
     {
-      "entity": "geoId/10",
+      "node": "geoId/10",
       "properties":
       [
         "administrativeCapital",
         "alternateName",
         "archinformLocationId",
-        "area",
-        "babelnetId",
-        "bbcThingsId",
-        "containedInPlace",
-        "czechNkcrAutId",
-        "encyclopediaBritannicaOnlineId",
-        "encyclopediaLarousseId",
-        "finlandYsoId",
-        "fips104",
-        "fips52AlphaCode",
-        "franceIdRefId",
-        "franceNationalLibraryId",
-        "gacsId",
-        "geoId",
-        "geoJsonCoordinates",
-        "geoJsonCoordinatesDP1",
-        "geoJsonCoordinatesDP2",
-        "geoJsonCoordinatesDP3",
-        "gettyThesaurusOfGeographicNamesId",
-        "gndId",
-        "gnisId",
-        "granEnciclopediaCatalanaId",
-        "isoCode",
-        "israelNationalLibraryId",
-        "kmlCoordinates",
-        "landArea",
-        "latitude",
-        "libraryOfCongressAuthorityId",
-        "longitude",
-        "musicbrainzAreaId",
-        "name",
-        "nameWithLanguage",
-        "nearbyPlaces",
-        "osmRelationId",
-        "provenance",
-        "quoraTopicId",
-        "ringgoldId",
-        "selibrId",
-        "swedishNationalEncyclopediaId",
-        "typeOf",
-        "unitedStatesNationalArchivesIdentifier",
-        "viafId",
-        "waterArea",
+        < ... output truncated for brevity ... >
         "whosOnFirstId",
         "wikidataId",
         "worldcatIdentitiesId"
@@ -335,5 +210,3 @@ Response:
 }
 ```
 {: .example-box-content .scroll}
- 
- 

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -149,7 +149,7 @@ Request:
 
 ```bash
 $ curl --request POST \
---url https://api.datacommons.org/v1/bulk/end/point \
+--url https://api.datacommons.org/v1/bulk/properties \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
 --data '{"entities":["geoId/51", "geoId/24", "geoId/10"]}'
 ```

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -149,7 +149,7 @@ Request:
 
 ```bash
 $ curl --request POST \
---url https://api.datacommons.org/v1/bulk/properties \
+--url https://api.datacommons.org/v1/bulk/properties/out \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
 --data '{"entities":["geoId/51", "geoId/24", "geoId/10"]}'
 ```

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -1,0 +1,335 @@
+---
+layout: default
+title: Rest API Bulk Page Template
+parent: v1 REST
+grand_parent: API
+nav_exclude: true
+published: false
+permalink: /api/rest/v1/bulk/properties
+---
+
+# /v1/bulk/properties
+
+Get all [properties](/glossary.html#property) associated with a specific entity, for multiple entities.
+
+More specifically, this endpoint returns the labels of the edges connected to a specific node in the Data Commons Knowledge Graph. Edges in the graph are directed, so properties can either be labels for edges _towards_ or _away_ from the node. Outgoing edges correspond to properties of the node. Incoming edges denote that the node is the value of this property for some other node.
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    To the values of properties, see [/v1/bulk/property/values](/api/rest/v1/bulk/property/values).<br />
+    To find connected edges and nodes, see [/v1/bulk/triples](/api/rest/v1/bulk/triples).<br />
+    For querying a single entity with simpler output, see the [simple version](/api/rest/v1/properties) of this endpoint.
+</div>
+ 
+
+## Request
+
+<div class="api-tab">
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">GET Request</button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">POST Request</button>
+</div> 
+
+<div id="GET-request" class="api-tabcontent api-signature">
+https://api.datacommons.org/v1/bulk/properties/{EDGE_DIRECTION}?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+</div>
+
+<div id="POST-request" class="api-tabcontent api-signature">
+URL:
+https://api.datacommons.org/v1/bulk/properties/{EDGE_DIRECTION}
+
+Header:
+X-API-Key: {your_api_key}
+
+JSON Data:
+{
+  "entities": [
+    "{value_1}",
+    "{value_2}",
+    ...
+  ]
+}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+<script src="/assets/js/api-doc-tabs.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | description of parameter here |
+{: .doc-table }
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the entities to query. |
+{: .doc-table }
+ 
+ 
+
+## Response
+
+ 
+The response looks like:
+ 
+```json
+{
+  "data":
+  [
+    {
+      "entity": "entity_1_dcid",
+      "properties":
+      [
+        "property_1",
+        "property_2",
+        ...
+      ]
+    },
+    {
+      "entity": "entity_2_dcid",
+      "properties":
+      [
+        "property_1",
+        "property_2",
+        ...
+      ]
+      
+    }, ...
+  ]
+}
+```
+{: .response-signature .scroll}
+ 
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
+| properties | list | List of properties connected to the entity queried, for the direction specified in the request. |
+{: .doc-table}
+ 
+
+## Examples
+
+ 
+
+### Example 1: Get properties describing multiple entities.
+
+Get properties describing the US states of Virgina (DCID: `geoId/51`), Maryland (DCID: `geoId/24`), and Delaware (DCID: `geoId/10`).
+
+<div>
+{% tabs example1 %}
+ 
+{% tab example1 GET Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request GET --url \
+'https://api.datacommons.org/v1/bulk/properties/out?entities=geoId/51&entities=geoId/24&entities=geoId/10&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+ 
+{% tab example1 POST Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request POST \
+--url https://api.datacommons.org/v1/bulk/end/point \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities":["geoId/51", "geoId/24", "geoId/10"]}'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+{% endtabs %}
+</div>
+ 
+Response:
+{: .example-box-title}
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "geoId/51",
+      "properties":
+      [
+        "administrativeCapital",
+        "alternateName",
+        "archinformLocationId",
+        "area",
+        "babelnetId",
+        "bbcThingsId",
+        "containedInPlace",
+        "czechNkcrAutId",
+        "encyclopediaBritannicaOnlineId",
+        "encyclopediaLarousseId",
+        "finlandYsoId",
+        "fips104",
+        "fips52AlphaCode",
+        "gacsId",
+        "geoId",
+        "geoJsonCoordinates",
+        "geoJsonCoordinatesDP1",
+        "geoJsonCoordinatesDP2",
+        "geoJsonCoordinatesDP3",
+        "gettyThesaurusOfGeographicNamesId",
+        "gndId",
+        "gnisId",
+        "granEnciclopediaCatalanaId",
+        "greatRussianEncyclopediaOnlineId",
+        "isoCode",
+        "kmlCoordinates",
+        "landArea",
+        "latitude",
+        "libraryOfCongressAuthorityId",
+        "longitude",
+        "musicbrainzAreaId",
+        "name",
+        "nameWithLanguage",
+        "nationalDietLibraryId",
+        "nearbyPlaces",
+        "osmRelationId",
+        "provenance",
+        "quoraTopicId",
+        "ringgoldId",
+        "selibrId",
+        "typeOf",
+        "unitedStatesNationalArchivesIdentifier",
+        "viafId",
+        "waterArea",
+        "whosOnFirstId",
+        "wikidataId",
+        "worldcatIdentitiesId"
+      ]
+    },
+    {
+      "entity": "geoId/24",
+      "properties":
+      [
+        "administrativeCapital",
+        "alternateName",
+        "archinformLocationId",
+        "area",
+        "babelnetId",
+        "bbcThingsId",
+        "containedInPlace",
+        "czechNkcrAutId",
+        "encyclopediaBritannicaOnlineId",
+        "encyclopediaLarousseId",
+        "finlandYsoId",
+        "fips104",
+        "fips52AlphaCode",
+        "franceNationalLibraryId",
+        "gacsId",
+        "geoId",
+        "geoJsonCoordinates",
+        "geoJsonCoordinatesDP1",
+        "geoJsonCoordinatesDP2",
+        "geoJsonCoordinatesDP3",
+        "gettyThesaurusOfGeographicNamesId",
+        "gndId",
+        "gnisId",
+        "granEnciclopediaCatalanaId",
+        "isoCode",
+        "israelNationalLibraryId",
+        "kmlCoordinates",
+        "landArea",
+        "latitude",
+        "libraryOfCongressAuthorityId",
+        "longitude",
+        "musicbrainzAreaId",
+        "name",
+        "nameWithLanguage",
+        "nationalDietLibraryId",
+        "nearbyPlaces",
+        "osmRelationId",
+        "provenance",
+        "quoraTopicId",
+        "ringgoldId",
+        "selibrId",
+        "spainNationalLibraryId",
+        "swedishNationalEncyclopediaId",
+        "typeOf",
+        "unitedStatesNationalArchivesIdentifier",
+        "viafId",
+        "waterArea",
+        "whosOnFirstId",
+        "wikidataId",
+        "worldcatIdentitiesId"
+      ]
+    },
+    {
+      "entity": "geoId/10",
+      "properties":
+      [
+        "administrativeCapital",
+        "alternateName",
+        "archinformLocationId",
+        "area",
+        "babelnetId",
+        "bbcThingsId",
+        "containedInPlace",
+        "czechNkcrAutId",
+        "encyclopediaBritannicaOnlineId",
+        "encyclopediaLarousseId",
+        "finlandYsoId",
+        "fips104",
+        "fips52AlphaCode",
+        "franceIdRefId",
+        "franceNationalLibraryId",
+        "gacsId",
+        "geoId",
+        "geoJsonCoordinates",
+        "geoJsonCoordinatesDP1",
+        "geoJsonCoordinatesDP2",
+        "geoJsonCoordinatesDP3",
+        "gettyThesaurusOfGeographicNamesId",
+        "gndId",
+        "gnisId",
+        "granEnciclopediaCatalanaId",
+        "isoCode",
+        "israelNationalLibraryId",
+        "kmlCoordinates",
+        "landArea",
+        "latitude",
+        "libraryOfCongressAuthorityId",
+        "longitude",
+        "musicbrainzAreaId",
+        "name",
+        "nameWithLanguage",
+        "nearbyPlaces",
+        "osmRelationId",
+        "provenance",
+        "quoraTopicId",
+        "ringgoldId",
+        "selibrId",
+        "swedishNationalEncyclopediaId",
+        "typeOf",
+        "unitedStatesNationalArchivesIdentifier",
+        "viafId",
+        "waterArea",
+        "whosOnFirstId",
+        "wikidataId",
+        "worldcatIdentitiesId"
+      ]
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}
+ 
+ 

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Rest API Bulk Page Template
+title: Properties
 parent: v1 REST
 grand_parent: API
 nav_exclude: true

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -25,8 +25,12 @@ More specifically, this endpoint returns the labels of the edges connected to a 
 ## Request
 
 <div class="api-tab">
-  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">GET Request</button>
-  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">POST Request</button>
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">
+    GET Request
+  </button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
+    POST Request
+  </button>
 </div> 
 
 <div id="GET-request" class="api-tabcontent api-signature">

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -61,7 +61,7 @@ JSON Data:
 
 | Name                                                | Description                   |
 | --------------------------------------------------- | ----------------------------- |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | description of parameter here |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns properties represented by edges pointing _toward_ the entity provided. If `out`, returns properties represented by edges pointing _away_ from the entity provided. |
 {: .doc-table }
 
 ### Query Parameters

--- a/api/rest/v1/properties.md
+++ b/api/rest/v1/properties.md
@@ -10,15 +10,19 @@ permalink: /api/rest/v1/properties
 
 # /v1/properties
 
-Get all [properties](/glossary.html#property) associated with a specific entity.
+Get all [properties](/glossary.html#property) associated with a specific node.
 
-More specifically, this endpoint returns the labels of the edges connected to a specific node in the Data Commons Knowledge Graph. Edges in the graph are directed, so properties can either be labels for edges _towards_ or _away_ from the node. Outgoing edges correspond to properties of the node. Incoming edges denote that the node is the value of this property for some other node.
+More specifically, this endpoint returns the labels of the edges connected to a
+specific node in the Data Commons Knowledge Graph. Edges in the graph are
+directed, so properties can either be labels for edges _towards_ or _away_ from
+the node. Outgoing edges correspond to properties of the node. Incoming edges
+denote that the node is the value of this property for some other node.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To find all possible values of a specific property, see [/v1/property/values](/api/rest/v1/property/values).<br />
     To find connected edges and nodes, see [/v1/triples](/api/rest/v1/triples).<br />
-    For querying multiple entities, see the [bulk version](/api/rest/v1/bulk/properties) of this endpoint.
+    For querying multiple nodes, see the [bulk version](/api/rest/v1/bulk/properties) of this endpoint.
 </div>
 
 ## Request
@@ -27,24 +31,24 @@ GET Request
 {: .api-header}
 
 <div class="api-signature">
-http://api.datacommons.org/v1/properties/{EDGE_DIRECTION}/{ENTITY_DCID}?key={your_api_key}
+http://api.datacommons.org/v1/properties/{EDGE_DIRECTION}/{NODE_DCID}?key={your_api_key}
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
 
 ### Path Parameters
 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns properties for which the queried entity is a value. If `out`, returns properties that describe the queried entity. |
-| ENTITY_DCID <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query. |
+| Name                                                        | Description                                                                                                                                                           |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns properties for which the queried node is a value. If `out`, returns properties that describe the queried node. |
+| NODE_DCID <br /> <required-tag>Required</required-tag>    | [DCID](/glossary.html#dcid) of the node to query.                                                                                                                   |
 {: .doc-table }
 
 ### Query Parameters
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| Name                                             | Type   | Description                                                                                                                                                     |
+| ------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag> | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 {: .doc-table}
 
 ## Response
@@ -53,7 +57,7 @@ The response looks like:
 
 ```json
 {
-  "entity": "Entity DCID",
+  "node": "Node DCID",
   "properties": [
     "property_name_1",
     "property_name_2",
@@ -65,20 +69,22 @@ The response looks like:
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
-| properties | list | List of properties connected to the entity queried, for the direction specified in the request. |
+| Name       | Type   | Description                                                                                     |
+| ---------- | ------ | ----------------------------------------------------------------------------------------------- |
+| node     | string | [DCID](/glossary.html#dcid) of the node queried.                                              |
+| properties | list   | List of properties connected to the node queried, for the direction specified in the request. |
 {: .doc-table}
 
 ## Examples
 
-### Example 1: Get properties describing an entity
+### Example 1: Get properties describing a node
 
-Get all properties that describe the city of Chicago, IL, USA (DCID: `geoId/1714000`).
+Get all properties that describe the city of Chicago, IL, USA (DCID:
+`geoId/1714000`).
 
 Request:
 {: .example-box-title}
+
 ```bash
   $ curl --request GET --url \
   'https://api.datacommons.org/v1/properties/out/geoId/1714000'
@@ -87,11 +93,11 @@ Request:
 
 Response:
 {: .example-box-title}
+
 ```json
 {
-  "entity": "geoId/1714000",
-  "properties":
-  [
+  "node": "geoId/1714000",
+  "properties": [
     "alternateName",
     "ansiCode",
     "archinformLocationId",
@@ -147,12 +153,13 @@ Response:
 ```
 {: .example-box-content .scroll}
 
-### Example 2: Get properties that have the queried entity as a value
+### Example 2: Get properties that have the queried node as a value
 
 Find all properties that have carbon dioxide (DCID: `CarbonDioxide`) as a value.
 
 Request:
 {: .example-box-title}
+
 ```bash
   $ curl --request GET --url \
   'https://api.datacommons.org/v1/properties/in/CarbonDioxide&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
@@ -161,9 +168,10 @@ Request:
 
 Response:
 {: .example-box-title}
+
 ```json
 {
-  "entity": "CarbonDioxide",
+  "node": "CarbonDioxide",
   "properties": ["emittedThing"]
 }
 ```

--- a/api/rest/v1/properties.md
+++ b/api/rest/v1/properties.md
@@ -1,0 +1,170 @@
+---
+layout: default
+title: Properties
+nav_order: 5
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/properties
+---
+
+# /v1/properties
+
+Get all [properties](/glossary.html#property) associated with a specific entity.
+
+More specifically, this endpoint returns the labels of the edges connected to a specific node in the Data Commons Knowledge Graph. Edges in the graph are directed, so properties can either be labels for edges _towards_ or _away_ from the node. Outgoing edges correspond to properties of the node. Incoming edges denote that the node is the value of this property for some other node.
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    To find all possible values of a specific property, see [/v1/property/values](/api/rest/v1/property/values).<br />
+    To find connected edges and nodes, see [/v1/triples](/api/rest/v1/triples).<br />
+    For querying multiple entities, see the [bulk version](/api/rest/v1/bulk/properties) of this endpoint.
+</div>
+
+## Request
+
+GET Request
+{: .api-header}
+
+<div class="api-signature">
+http://api.datacommons.org/v1/properties/{EDGE_DIRECTION}/{ENTITY_DCID}?key={your_api_key}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns properties for which the queried entity is a value. If `out`, returns properties that describe the queried entity. |
+| ENTITY_DCID <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query. |
+{: .doc-table }
+
+### Query Parameters
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+{: .doc-table}
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "entity": "Entity DCID",
+  "properties": [
+    "property_name_1",
+    "property_name_2",
+    ...
+  ]
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
+| properties | list | List of properties connected to the entity queried, for the direction specified in the request. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Get properties describing an entity
+
+Get all properties that describe the city of Chicago, IL, USA (DCID: `geoId/1714000`).
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/properties/out/geoId/1714000'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "entity": "geoId/1714000",
+  "properties":
+  [
+    "alternateName",
+    "ansiCode",
+    "archinformLocationId",
+    "babelnetId",
+    "brockhausEncylcopediaOnlineId",
+    "censusAreaDescriptionCode",
+    "censusFunctionalStatusCode",
+    "containedInPlace",
+    "czechNkcrAutId",
+    "encyclopediaBritannicaOnlineId",
+    "encyclopediaUniversalisId",
+    "facebookPlacesId",
+    "finlandYsoId",
+    "fips553",
+    "franceNationalLibraryId",
+    "geoId",
+    "geoJsonCoordinates",
+    "geoOverlaps",
+    "gettyThesaurusOfGeographicNamesId",
+    "gndId",
+    "gnisId",
+    "granEnciclopediaCatalanaId",
+    "iataAirportCode",
+    "israelNationalLibraryId",
+    "kmlCoordinates",
+    "landArea",
+    "latitude",
+    "libraryOfCongressAuthorityId",
+    "longitude",
+    "musicbrainzAreaId",
+    "name",
+    "nameWithLanguage",
+    "nationalDietLibraryId",
+    "nearbyPlaces",
+    "osmRelationId",
+    "postalCode",
+    "provenance",
+    "quoraTopicId",
+    "swedishNationalEncyclopediaId",
+    "typeOf",
+    "unitedKingdomParliamentThesaurusId",
+    "unitedNationsLocode",
+    "unitedStatesNationalArchivesIdentifier",
+    "uppsalaUniversityAlvinId",
+    "viafId",
+    "waterArea",
+    "whereOnEarthId",
+    "whosOnFirstId",
+    "wikidataId",
+    "worldcatIdentitiesId"
+  ]
+}
+```
+{: .example-box-content .scroll}
+
+### Example 2: Get properties that have the queried entity as a value
+
+Find all properties that have carbon dioxide (DCID: `CarbonDioxide`) as a value.
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/properties/in/CarbonDioxide&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "entity": "CarbonDioxide",
+  "properties": ["emittedThing"]
+}
+```
+{: .example-box-content .scroll}


### PR DESCRIPTION
This PR adds the documentation pages for:
* [v1/properties](https://juliawu.github.io/datacommons-docsite/api/rest/v1/properties)
* [v1/bulk/properties](https://juliawu.github.io/datacommons-docsite/api/rest/v1/bulk/properties)

Pages are still unpublished. Final ordering of sidebar and landing page links will happen in a separate PR once all pages are in, before publishing.