### PR TITLE
[v1 API Docs] Add v1*/variables pages

### DIFF
--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -1,0 +1,363 @@
+---
+layout: default
+title: Variables
+parent: v1 REST
+grand_parent: API
+nav_exclude: true
+published: false
+permalink: /api/rest/v1/bulk/variables
+---
+
+# /v1/bulk/variables
+
+Get all [variables](/glossary.html#variable) associated with a specific entity, for multiple entities.
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    For querying a single entity with simpler output, see the [simple version](/api/rest/v1/variables) of this endpoint.
+</div>
+ 
+
+## Request
+
+<div class="api-tab">
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">
+    GET Request
+  </button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
+    POST Request
+  </button>
+</div> 
+
+<div id="GET-request" class="api-tabcontent api-signature">
+https://api.datacommons.org/v1/bulk/variables?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+</div>
+
+<div id="POST-request" class="api-tabcontent api-signature">
+URL:
+https://api.datacommons.org/v1/bulk/variables
+
+Header:
+X-API-Key: {your_api_key}
+
+JSON Data:
+{
+  "entities": [
+    "{entity_dcid_1}",
+    "{entity_dcid_2}",
+    ...
+  ]
+}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+<script src="/assets/js/api-doc-tabs.js"></script>
+
+### Path Parameters
+
+There are no path parameters for this endpoint.
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| variables | list | List of variables associated with the entity queried. |
+{: .doc-table }
+ 
+ 
+
+## Response
+
+ 
+The response looks like:
+ 
+```json
+{
+  "data":
+  [
+    {
+      "entity": "entity_dcid_1",
+      "variables":
+      [
+        "variable_dcid_1",
+        "variable_dcid_2",
+        ...
+      ]
+    },
+    {
+      "entity": "entity_dcid_2",
+      "variables":
+      [
+        "variable_dcid_1",
+        "variable_dcid_2",
+        ...
+      ], ...
+    }
+  ]
+}
+```
+{: .response-signature .scroll}
+ 
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
+| properties | list | List of properties connected to the entity queried, for the direction specified in the request. |
+{: .doc-table}
+ 
+
+## Examples
+
+ 
+
+### Example 1: Get variables associated with multiple entities.
+
+Get variables for the cities of Tokyo, Japan (DCID: `wikidataId/Q1490`) and Seoul, South Korea (DCID: `wikidataId/Q8684`).
+
+<div>
+{% tabs example1 %}
+ 
+{% tab example1 GET Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request GET --url \
+'https://api.datacommons.org/v1/bulk/variables?entities=wikidataId/Q1490&entities=wikidataId/Q8684&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+ 
+{% tab example1 POST Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request POST \
+--url https://api.datacommons.org/v1/bulk/variables \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities":["wikidataId/Q1490", "wikidataId/Q8684"]}'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+{% endtabs %}
+</div>
+ 
+Response:
+{: .example-box-title}
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "wikidataId/Q1490",
+      "variables":
+      [
+        "Count_CycloneEvent",
+        "Count_CycloneEvent_TropicalStorm",
+        "Count_Person",
+        "Max_Rainfall",
+        "Max_Snowfall",
+        "Max_Temperature",
+        "Mean_BarometricPressure",
+        "Mean_Rainfall",
+        "Mean_Snowfall",
+        "Mean_Temperature",
+        "Mean_Visibility",
+        "Min_Rainfall",
+        "Min_Snowfall",
+        "Min_Temperature"
+      ]
+    },
+    {
+      "entity": "wikidataId/Q8684",
+      "variables":
+      [
+        "Count_Death",
+        "Count_Death_10To14Years_Female",
+        "Count_Death_10To14Years_Male",
+        "Count_Death_15To19Years",
+        "Count_Death_15To19Years_Male",
+        "Count_Death_15To64Years",
+        "Count_Death_15To64Years_Female",
+        "Count_Death_15To64Years_Male",
+        "Count_Death_20To24Years",
+        "Count_Death_20To24Years_Female",
+        "Count_Death_20To24Years_Male",
+        "Count_Death_25To29Years_Female",
+        "Count_Death_25To29Years_Male",
+        "Count_Death_25To34Years",
+        "Count_Death_25To34Years_Female",
+        "Count_Death_25To34Years_Male",
+        "Count_Death_30To34Years",
+        "Count_Death_30To34Years_Female",
+        "Count_Death_30To34Years_Male",
+        "Count_Death_35To39Years_Male",
+        "Count_Death_35To44Years_Female",
+        "Count_Death_35To44Years_Male",
+        "Count_Death_40To44Years_Female",
+        "Count_Death_40To44Years_Male",
+        "Count_Death_45To49Years_Female",
+        "Count_Death_45To54Years_Female",
+        "Count_Death_50To54Years_Female",
+        "Count_Death_55To59Years_Female",
+        "Count_Death_55To59Years_Male",
+        "Count_Death_55To64Years",
+        "Count_Death_55To64Years_Female",
+        "Count_Death_55To64Years_Male",
+        "Count_Death_5To9Years_Female",
+        "Count_Death_5To9Years_Male",
+        "Count_Death_60To64Years",
+        "Count_Death_60To64Years_Female",
+        "Count_Death_65OrMoreYears",
+        "Count_Death_65OrMoreYears_Female",
+        "Count_Death_65OrMoreYears_Male",
+        "Count_Death_65To74Years_Female",
+        "Count_Death_70To74Years_Female",
+        "Count_Death_75To79Years",
+        "Count_Death_75To79Years_Female",
+        "Count_Death_80OrMoreYears",
+        "Count_Death_80OrMoreYears_Female",
+        "Count_Death_80OrMoreYears_Male",
+        "Count_Death_AgeAdjusted_AsAFractionOf_Count_Person",
+        "Count_Death_AsAFractionOfCount_Person",
+        "Count_Death_Female",
+        "Count_Death_Female_AgeAdjusted_AsAFractionOf_Count_Person_Female",
+        "Count_Death_Female_AsAFractionOf_Count_Person_Female",
+        "Count_Death_LessThan1Year_AsAFractionOf_Count_BirthEvent",
+        "Count_Death_LessThan1Year_Female_AsAFractionOf_Count_BirthEvent_Female",
+        "Count_Death_LessThan1Year_Male_AsAFractionOf_Count_BirthEvent_Male",
+        "Count_Death_Male",
+        "Count_Death_Male_AgeAdjusted_AsAFractionOf_Count_Person_Male",
+        "Count_Death_Male_AsAFractionOf_Count_Person_Male",
+        "Count_Death_Upto14Years",
+        "Count_Death_Upto14Years_AsAFractionOf_Count_Person_Upto14Years",
+        "Count_Death_Upto14Years_Female",
+        "Count_Death_Upto14Years_Female_AsAFractionOf_Count_Person_Upto14Years_Female",
+        "Count_Death_Upto14Years_Male",
+        "Count_Death_Upto14Years_Male_AsAFractionOf_Count_Person_Upto14Years_Male",
+        "Count_Death_Upto4Years_Female",
+        "Count_Death_Upto4Years_Male",
+        "Count_Person",
+        "Count_Person_10To14Years",
+        "Count_Person_10To14Years_Female",
+        "Count_Person_10To14Years_Male",
+        "Count_Person_15To19Years",
+        "Count_Person_15To19Years_Female",
+        "Count_Person_15To19Years_Male",
+        "Count_Person_15To64Years",
+        "Count_Person_15To64Years_Female",
+        "Count_Person_15To64Years_Male",
+        "Count_Person_20To24Years",
+        "Count_Person_20To24Years_Female",
+        "Count_Person_20To24Years_Male",
+        "Count_Person_25To29Years",
+        "Count_Person_25To29Years_Female",
+        "Count_Person_25To29Years_Male",
+        "Count_Person_25To34Years",
+        "Count_Person_25To34Years_Female",
+        "Count_Person_25To34Years_Male",
+        "Count_Person_30To34Years",
+        "Count_Person_30To34Years_Female",
+        "Count_Person_30To34Years_Male",
+        "Count_Person_35To39Years",
+        "Count_Person_35To39Years_Female",
+        "Count_Person_35To39Years_Male",
+        "Count_Person_35To44Years",
+        "Count_Person_35To44Years_Female",
+        "Count_Person_35To44Years_Male",
+        "Count_Person_40To44Years",
+        "Count_Person_40To44Years_Female",
+        "Count_Person_40To44Years_Male",
+        "Count_Person_45To49Years",
+        "Count_Person_45To49Years_Female",
+        "Count_Person_45To49Years_Male",
+        "Count_Person_45To54Years",
+        "Count_Person_45To54Years_Female",
+        "Count_Person_45To54Years_Male",
+        "Count_Person_50To54Years",
+        "Count_Person_50To54Years_Female",
+        "Count_Person_50To54Years_Male",
+        "Count_Person_55To59Years",
+        "Count_Person_55To59Years_Female",
+        "Count_Person_55To59Years_Male",
+        "Count_Person_55To64Years",
+        "Count_Person_55To64Years_Female",
+        "Count_Person_55To64Years_Male",
+        "Count_Person_5To9Years",
+        "Count_Person_5To9Years_Female",
+        "Count_Person_5To9Years_Male",
+        "Count_Person_60To64Years",
+        "Count_Person_60To64Years_Female",
+        "Count_Person_60To64Years_Male",
+        "Count_Person_65OrMoreYears",
+        "Count_Person_65OrMoreYears_Female",
+        "Count_Person_65OrMoreYears_Male",
+        "Count_Person_65To69Years",
+        "Count_Person_65To69Years_Female",
+        "Count_Person_65To69Years_Male",
+        "Count_Person_65To74Years",
+        "Count_Person_70To74Years",
+        "Count_Person_70To74Years_Female",
+        "Count_Person_70To74Years_Male",
+        "Count_Person_75OrMoreYears",
+        "Count_Person_75OrMoreYears_Female",
+        "Count_Person_75OrMoreYears_Male",
+        "Count_Person_75To79Years",
+        "Count_Person_75To79Years_Female",
+        "Count_Person_75To79Years_Male",
+        "Count_Person_80OrMoreYears",
+        "Count_Person_80OrMoreYears_Female",
+        "Count_Person_80OrMoreYears_Male",
+        "Count_Person_Female",
+        "Count_Person_Male",
+        "Count_Person_PerArea",
+        "Count_Person_Upto14Years",
+        "Count_Person_Upto14Years_Female",
+        "Count_Person_Upto14Years_Male",
+        "Count_Person_Upto4Years",
+        "Count_Person_Upto4Years_Female",
+        "Count_Person_Upto4Years_Male",
+        "LifeExpectancy_Person",
+        "LifeExpectancy_Person_Female",
+        "LifeExpectancy_Person_Male",
+        "Max_Rainfall",
+        "Max_Snowfall",
+        "Max_Temperature",
+        "Mean_BarometricPressure",
+        "Mean_Rainfall",
+        "Mean_Snowfall",
+        "Mean_Temperature",
+        "Mean_Visibility",
+        "Min_Rainfall",
+        "Min_Snowfall",
+        "Min_Temperature",
+        "dc/505bwby61yjz3",
+        "dc/5by90fh61z2s4",
+        "dc/6zsphg3yq6znf",
+        "dc/e0j2t6nv29jz5",
+        "dc/lttwq8h183gq6",
+        "dc/nf9577mjqs69g",
+        "dc/qg9n5wq1e7zg3",
+        "dc/rxg50w6jfgld4",
+        "dc/sw43w4pbtgq4d",
+        "dc/x73k9t2mzzcs2",
+        "dc/xh9d9e2le1r41"
+      ]
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}
+ 
+ 

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -105,7 +105,7 @@ The response looks like:
 | Name     | Type   | Description                |
 | -------- | ------ | -------------------------- |
 | entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
-| properties | list | List of properties connected to the entity queried, for the direction specified in the request. |
+| variables | list | List of variables connected to the entity queried. |
 {: .doc-table}
  
 

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -10,13 +10,14 @@ permalink: /api/rest/v1/bulk/variables
 
 # /v1/bulk/variables
 
-Get all [variables](/glossary.html#variable) associated with a specific entity, for multiple entities.
+Get all [variables](/glossary.html#variable) with data associated with a
+specific entity, for multiple entities.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For querying a single entity with simpler output, see the [simple version](/api/rest/v1/variables) of this endpoint.
 </div>
- 
+
 
 ## Request
 
@@ -27,7 +28,7 @@ Get all [variables](/glossary.html#variable) associated with a specific entity, 
   <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
     POST Request
   </button>
-</div> 
+</div>
 
 <div id="GET-request" class="api-tabcontent api-signature">
 https://api.datacommons.org/v1/bulk/variables?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
@@ -42,12 +43,14 @@ X-API-Key: {your_api_key}
 
 JSON Data:
 {
-  "entities": [
-    "{entity_dcid_1}",
-    "{entity_dcid_2}",
-    ...
-  ]
+  "entities":
+    [
+      "{entity_dcid_1}",
+      "{entity_dcid_2}",
+      ...
+    ]
 }
+
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -59,19 +62,16 @@ There are no path parameters for this endpoint.
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| variables | list | List of variables associated with the entity queried. |
+| Name                                                   | Type   | Description                                                                                                                                                     |
+| ------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag>       | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| variables <br /> <required-tag>Required</required-tag> | list   | List of variables associated with the entity queried.                                                                                                           |
 {: .doc-table }
- 
- 
 
 ## Response
 
- 
 The response looks like:
- 
+
 ```json
 {
   "data":
@@ -98,24 +98,21 @@ The response looks like:
 }
 ```
 {: .response-signature .scroll}
- 
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
-| variables | list | List of variables connected to the entity queried. |
+| Name      | Type   | Description                                        |
+| --------- | ------ | -------------------------------------------------- |
+| entity    | string | [DCID](/glossary.html#dcid) of the entity queried. |
+| variables | list   | List of variables connected to the entity queried. |
 {: .doc-table}
- 
 
 ## Examples
 
- 
-
 ### Example 1: Get variables associated with multiple entities.
 
-Get variables for the cities of Tokyo, Japan (DCID: `wikidataId/Q1490`) and Seoul, South Korea (DCID: `wikidataId/Q8684`).
+Get variables for the cities of Tokyo, Japan (DCID: `wikidataId/Q1490`) and
+Seoul, South Korea (DCID: `wikidataId/Q8684`).
 
 <div>
 {% tabs example1 %}
@@ -130,12 +127,11 @@ $ curl --request GET --url \
 'https://api.datacommons.org/v1/bulk/variables?entities=wikidataId/Q1490&entities=wikidataId/Q8684&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
- 
+
 {% tab example1 POST Request %}
- 
+
 Request:
 {: .example-box-title}
 
@@ -146,10 +142,11 @@ $ curl --request POST \
 --data '{"entities":["wikidataId/Q1490", "wikidataId/Q8684"]}'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
+
 {% endtabs %}
+
 </div>
  
 Response:
@@ -166,14 +163,7 @@ Response:
         "Count_CycloneEvent",
         "Count_CycloneEvent_TropicalStorm",
         "Count_Person",
-        "Max_Rainfall",
-        "Max_Snowfall",
-        "Max_Temperature",
-        "Mean_BarometricPressure",
-        "Mean_Rainfall",
-        "Mean_Snowfall",
-        "Mean_Temperature",
-        "Mean_Visibility",
+        < ... output truncated for brevity ... >
         "Min_Rainfall",
         "Min_Snowfall",
         "Min_Temperature"
@@ -186,170 +176,7 @@ Response:
         "Count_Death",
         "Count_Death_10To14Years_Female",
         "Count_Death_10To14Years_Male",
-        "Count_Death_15To19Years",
-        "Count_Death_15To19Years_Male",
-        "Count_Death_15To64Years",
-        "Count_Death_15To64Years_Female",
-        "Count_Death_15To64Years_Male",
-        "Count_Death_20To24Years",
-        "Count_Death_20To24Years_Female",
-        "Count_Death_20To24Years_Male",
-        "Count_Death_25To29Years_Female",
-        "Count_Death_25To29Years_Male",
-        "Count_Death_25To34Years",
-        "Count_Death_25To34Years_Female",
-        "Count_Death_25To34Years_Male",
-        "Count_Death_30To34Years",
-        "Count_Death_30To34Years_Female",
-        "Count_Death_30To34Years_Male",
-        "Count_Death_35To39Years_Male",
-        "Count_Death_35To44Years_Female",
-        "Count_Death_35To44Years_Male",
-        "Count_Death_40To44Years_Female",
-        "Count_Death_40To44Years_Male",
-        "Count_Death_45To49Years_Female",
-        "Count_Death_45To54Years_Female",
-        "Count_Death_50To54Years_Female",
-        "Count_Death_55To59Years_Female",
-        "Count_Death_55To59Years_Male",
-        "Count_Death_55To64Years",
-        "Count_Death_55To64Years_Female",
-        "Count_Death_55To64Years_Male",
-        "Count_Death_5To9Years_Female",
-        "Count_Death_5To9Years_Male",
-        "Count_Death_60To64Years",
-        "Count_Death_60To64Years_Female",
-        "Count_Death_65OrMoreYears",
-        "Count_Death_65OrMoreYears_Female",
-        "Count_Death_65OrMoreYears_Male",
-        "Count_Death_65To74Years_Female",
-        "Count_Death_70To74Years_Female",
-        "Count_Death_75To79Years",
-        "Count_Death_75To79Years_Female",
-        "Count_Death_80OrMoreYears",
-        "Count_Death_80OrMoreYears_Female",
-        "Count_Death_80OrMoreYears_Male",
-        "Count_Death_AgeAdjusted_AsAFractionOf_Count_Person",
-        "Count_Death_AsAFractionOfCount_Person",
-        "Count_Death_Female",
-        "Count_Death_Female_AgeAdjusted_AsAFractionOf_Count_Person_Female",
-        "Count_Death_Female_AsAFractionOf_Count_Person_Female",
-        "Count_Death_LessThan1Year_AsAFractionOf_Count_BirthEvent",
-        "Count_Death_LessThan1Year_Female_AsAFractionOf_Count_BirthEvent_Female",
-        "Count_Death_LessThan1Year_Male_AsAFractionOf_Count_BirthEvent_Male",
-        "Count_Death_Male",
-        "Count_Death_Male_AgeAdjusted_AsAFractionOf_Count_Person_Male",
-        "Count_Death_Male_AsAFractionOf_Count_Person_Male",
-        "Count_Death_Upto14Years",
-        "Count_Death_Upto14Years_AsAFractionOf_Count_Person_Upto14Years",
-        "Count_Death_Upto14Years_Female",
-        "Count_Death_Upto14Years_Female_AsAFractionOf_Count_Person_Upto14Years_Female",
-        "Count_Death_Upto14Years_Male",
-        "Count_Death_Upto14Years_Male_AsAFractionOf_Count_Person_Upto14Years_Male",
-        "Count_Death_Upto4Years_Female",
-        "Count_Death_Upto4Years_Male",
-        "Count_Person",
-        "Count_Person_10To14Years",
-        "Count_Person_10To14Years_Female",
-        "Count_Person_10To14Years_Male",
-        "Count_Person_15To19Years",
-        "Count_Person_15To19Years_Female",
-        "Count_Person_15To19Years_Male",
-        "Count_Person_15To64Years",
-        "Count_Person_15To64Years_Female",
-        "Count_Person_15To64Years_Male",
-        "Count_Person_20To24Years",
-        "Count_Person_20To24Years_Female",
-        "Count_Person_20To24Years_Male",
-        "Count_Person_25To29Years",
-        "Count_Person_25To29Years_Female",
-        "Count_Person_25To29Years_Male",
-        "Count_Person_25To34Years",
-        "Count_Person_25To34Years_Female",
-        "Count_Person_25To34Years_Male",
-        "Count_Person_30To34Years",
-        "Count_Person_30To34Years_Female",
-        "Count_Person_30To34Years_Male",
-        "Count_Person_35To39Years",
-        "Count_Person_35To39Years_Female",
-        "Count_Person_35To39Years_Male",
-        "Count_Person_35To44Years",
-        "Count_Person_35To44Years_Female",
-        "Count_Person_35To44Years_Male",
-        "Count_Person_40To44Years",
-        "Count_Person_40To44Years_Female",
-        "Count_Person_40To44Years_Male",
-        "Count_Person_45To49Years",
-        "Count_Person_45To49Years_Female",
-        "Count_Person_45To49Years_Male",
-        "Count_Person_45To54Years",
-        "Count_Person_45To54Years_Female",
-        "Count_Person_45To54Years_Male",
-        "Count_Person_50To54Years",
-        "Count_Person_50To54Years_Female",
-        "Count_Person_50To54Years_Male",
-        "Count_Person_55To59Years",
-        "Count_Person_55To59Years_Female",
-        "Count_Person_55To59Years_Male",
-        "Count_Person_55To64Years",
-        "Count_Person_55To64Years_Female",
-        "Count_Person_55To64Years_Male",
-        "Count_Person_5To9Years",
-        "Count_Person_5To9Years_Female",
-        "Count_Person_5To9Years_Male",
-        "Count_Person_60To64Years",
-        "Count_Person_60To64Years_Female",
-        "Count_Person_60To64Years_Male",
-        "Count_Person_65OrMoreYears",
-        "Count_Person_65OrMoreYears_Female",
-        "Count_Person_65OrMoreYears_Male",
-        "Count_Person_65To69Years",
-        "Count_Person_65To69Years_Female",
-        "Count_Person_65To69Years_Male",
-        "Count_Person_65To74Years",
-        "Count_Person_70To74Years",
-        "Count_Person_70To74Years_Female",
-        "Count_Person_70To74Years_Male",
-        "Count_Person_75OrMoreYears",
-        "Count_Person_75OrMoreYears_Female",
-        "Count_Person_75OrMoreYears_Male",
-        "Count_Person_75To79Years",
-        "Count_Person_75To79Years_Female",
-        "Count_Person_75To79Years_Male",
-        "Count_Person_80OrMoreYears",
-        "Count_Person_80OrMoreYears_Female",
-        "Count_Person_80OrMoreYears_Male",
-        "Count_Person_Female",
-        "Count_Person_Male",
-        "Count_Person_PerArea",
-        "Count_Person_Upto14Years",
-        "Count_Person_Upto14Years_Female",
-        "Count_Person_Upto14Years_Male",
-        "Count_Person_Upto4Years",
-        "Count_Person_Upto4Years_Female",
-        "Count_Person_Upto4Years_Male",
-        "LifeExpectancy_Person",
-        "LifeExpectancy_Person_Female",
-        "LifeExpectancy_Person_Male",
-        "Max_Rainfall",
-        "Max_Snowfall",
-        "Max_Temperature",
-        "Mean_BarometricPressure",
-        "Mean_Rainfall",
-        "Mean_Snowfall",
-        "Mean_Temperature",
-        "Mean_Visibility",
-        "Min_Rainfall",
-        "Min_Snowfall",
-        "Min_Temperature",
-        "dc/505bwby61yjz3",
-        "dc/5by90fh61z2s4",
-        "dc/6zsphg3yq6znf",
-        "dc/e0j2t6nv29jz5",
-        "dc/lttwq8h183gq6",
-        "dc/nf9577mjqs69g",
-        "dc/qg9n5wq1e7zg3",
-        "dc/rxg50w6jfgld4",
+        < ... output truncated for brevity ...>
         "dc/sw43w4pbtgq4d",
         "dc/x73k9t2mzzcs2",
         "dc/xh9d9e2le1r41"
@@ -359,5 +186,3 @@ Response:
 }
 ```
 {: .example-box-content .scroll}
- 
- 

--- a/api/rest/v1/variables.md
+++ b/api/rest/v1/variables.md
@@ -1,0 +1,104 @@
+---
+layout: default
+title: Variables
+nav_order: 8
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/variables
+---
+
+# /v1/variables
+
+Get all [variables](/glossary.html#variable) associated with a specific entity.
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    For querying multiple entities, see the [bulk version](/api/rest/v1/bulk/variables) of this endpoint.
+</div>
+
+## Request
+
+GET Request
+{: .api-header}
+
+<div class="api-signature">
+http://api.datacommons.org/v1/variables/{ENTITY_DCID}?key={your_api_key}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| ENTITY_DCID <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query. |
+{: .doc-table }
+
+### Query Parameters
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+{: .doc-table}
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "entity": "Entity DCID",
+  "variables": [
+    "variable_dcid_1",
+    "variable_dcid_2",
+    ...
+  ]
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
+| variables | list | List of variables associated with the entity queried. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Get variables for an entity
+
+Get all properties that describe the city of Hagåtña, the capital of Guam. (DCID: `wikidataId/Q30988`).
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/variables/wikidataId/Q30988'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "entity": "wikidataId/Q30988",
+  "variables": [
+    "Count_Person",
+    "Max_Rainfall",
+    "Max_Snowfall",
+    "Max_Temperature",
+    "Mean_BarometricPressure",
+    "Mean_Rainfall",
+    "Mean_Snowfall",
+    "Mean_Temperature",
+    "Mean_Visibility",
+    "Min_Rainfall",
+    "Min_Snowfall",
+    "Min_Temperature"
+  ]
+}
+```
+{: .example-box-content .scroll}

--- a/api/rest/v1/variables.md
+++ b/api/rest/v1/variables.md
@@ -10,7 +10,7 @@ permalink: /api/rest/v1/variables
 
 # /v1/variables
 
-Get all [variables](/glossary.html#variable) associated with a specific entity.
+Get all [variables](/glossary.html#variable) with data associated with a specific entity.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />


### PR DESCRIPTION
This PR adds the documentation pages for:
* [v1/variables](https://juliawu.github.io/datacommons-docsite/api/rest/v1/variables)
* [v1/bulk/variables](https://juliawu.github.io/datacommons-docsite/api/rest/v1/bulk/variables)

Pages are still unpublished. Final ordering of sidebar and landing page links will happen in a separate PR once all pages are in, before publishing.