### PR TITLE
[v1 API Docs] add */triples pages

### DIFF
--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -12,13 +12,13 @@ permalink: /api/rest/v1/bulk/triples
 
 Get [triples](/glossary.html#triple) for multiple entities.
 
-Useful for finding local connections between nodes of the Data Commons knowledge graph.
+Useful for finding local connections between nodes of the Data Commons knowledge
+graph.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For single queries with a simpler output, see the [simple version](/api/rest/v1/triples) of this endpoint.
 </div>
- 
 
 ## Request
 
@@ -29,7 +29,7 @@ Useful for finding local connections between nodes of the Data Commons knowledge
   <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
     POST Request
   </button>
-</div> 
+</div>
 
 <div id="GET-request" class="api-tabcontent api-signature">
 https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
@@ -39,17 +39,10 @@ https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}?entities={entity_dc
 URL:
 https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}
 
-Header:
-X-API-Key: {your_api_key}
+Header: X-API-Key: {your_api_key}
 
-JSON Data:
-{
-  "entities": [
-    "{value_1}",
-    "{value_2}",
-    ...
-  ]
-}
+JSON Data: { "entities": [ "{value_1}", "{value_2}", ... ] }
+
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -57,26 +50,23 @@ JSON Data:
 
 ### Path Parameters
 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
+| Name                                                        | Description                                                                                                                                                                                                                                |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the entity provided. If `out`, returns triples with edges pointing _away_ from the entity provided. |
 {: .doc-table }
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the entities to query. |
+| Name                                                  | Type   | Description                                                                                                                                                     |
+| ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag>      | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the entities to query.                                                                                                          |
 {: .doc-table }
- 
- 
 
 ## Response
 
- 
 The response looks like:
- 
+
 ```json
 {
   "data":
@@ -120,24 +110,21 @@ The response looks like:
 }
 ```
 {: .response-signature .scroll}
- 
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
-| triples    | object   | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
+| Name    | Type   | Description                                                                                                                                                                       |
+| ------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| entity  | string | [DCID](/glossary.html#dcid) of the entity queried.                                                                                                                                |
+| triples | object | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
 {: .doc-table}
- 
 
 ## Examples
 
- 
-
 ### Example 1: Get outgoing triples for multiple entities.
 
-Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and methane (DCID: `Methane`), for edges going _away_ from those nodes.
+Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and
+methane (DCID: `Methane`), for edges going _away_ from those nodes.
 
 <div>
 {% tabs example1 %}
@@ -152,12 +139,11 @@ $ curl --request GET --url \
 'https://api.datacommons.org/v1/bulk/triples/out?entities=CarbonDioxide&entities=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
- 
+
 {% tab example1 POST Request %}
- 
+
 Request:
 {: .example-box-title}
 
@@ -168,47 +154,40 @@ $ curl --request POST \
 --data '{"entities":["CarbonDioxide", "Methane"]}'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
+
 {% endtabs %}
+
 </div>
- 
+
 Response:
 {: .example-box-title}
 
 ```json
 {
-  "data":
-  [
+  "data": [
     {
       "entity": "CarbonDioxide",
-      "triples":
-      {
-        "description":
-        {
-          "entities":
-          [
+      "triples": {
+        "description": {
+          "entities": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "A colorless gas consisting of a carbon atom covalently double bonded to two oxygen atoms."
             }
           ]
         },
-        "descriptionUrl":
-        {
-          "entities":
-          [
+        "descriptionUrl": {
+          "entities": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "https://en.wikipedia.org/wiki/Carbon_dioxide"
             }
           ]
         },
-        "name":
-        {
-          "entities":
-          [
+        "name": {
+          "entities": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "Carbon Dioxide"
@@ -219,40 +198,27 @@ Response:
             }
           ]
         },
-        "provenance":
-        {
-          "entities":
-          [
+        "provenance": {
+          "entities": [
             {
               "name": "https://datacommons.org",
-              "types":
-              [
-                "Provenance"
-              ],
+              "types": ["Provenance"],
               "dcid": "dc/5l5zxr1",
               "provenanceId": "dc/5l5zxr1"
             }
           ]
         },
-        "typeOf":
-        {
-          "entities":
-          [
+        "typeOf": {
+          "entities": [
             {
               "name": "GasType",
-              "types":
-              [
-                "Class"
-              ],
+              "types": ["Class"],
               "dcid": "GasType",
               "provenanceId": "dc/5l5zxr1"
             },
             {
               "name": "GreenhouseGas",
-              "types":
-              [
-                "Class"
-              ],
+              "types": ["Class"],
               "dcid": "GreenhouseGas",
               "provenanceId": "dc/5l5zxr1"
             }
@@ -262,67 +228,46 @@ Response:
     },
     {
       "entity": "Methane",
-      "triples":
-      {
-        "isProvisional":
-        {
-          "entities":
-          [
+      "triples": {
+        "isProvisional": {
+          "entities": [
             {
               "name": "True",
-              "types":
-              [
-                "Boolean"
-              ],
+              "types": ["Boolean"],
               "dcid": "True",
               "provenanceId": "dc/5l5zxr1"
             }
           ]
         },
-        "name":
-        {
-          "entities":
-          [
+        "name": {
+          "entities": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "Methane"
             }
           ]
         },
-        "provenance":
-        {
-          "entities":
-          [
+        "provenance": {
+          "entities": [
             {
               "name": "https://datacommons.org",
-              "types":
-              [
-                "Provenance"
-              ],
+              "types": ["Provenance"],
               "dcid": "dc/5l5zxr1",
               "provenanceId": "dc/5l5zxr1"
             }
           ]
         },
-        "typeOf":
-        {
-          "entities":
-          [
+        "typeOf": {
+          "entities": [
             {
               "name": "ChemicalCompound",
-              "types":
-              [
-                "Class"
-              ],
+              "types": ["Class"],
               "dcid": "ChemicalCompound",
               "provenanceId": "dc/5l5zxr1"
             },
             {
               "name": "GreenhouseGas",
-              "types":
-              [
-                "Class"
-              ],
+              "types": ["Class"],
               "dcid": "GreenhouseGas",
               "provenanceId": "dc/5l5zxr1"
             }
@@ -334,11 +279,11 @@ Response:
 }
 ```
 {: .example-box-content .scroll}
- 
- 
+
 ### Example 2: Get incoming triples for multiple entities.
 
-Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and methane (DCID: `Methane`), for edges going _towards_ those nodes.
+Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and
+methane (DCID: `Methane`), for edges going _towards_ those nodes.
 
 <div>
 {% tabs example1 %}
@@ -353,12 +298,11 @@ $ curl --request GET --url \
 'https://api.datacommons.org/v1/bulk/triples/in?entities=geoId/51&entities=CarbonDioxide&entities=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
- 
+
 {% tab example1 POST Request %}
- 
+
 Request:
 {: .example-box-title}
 
@@ -369,10 +313,11 @@ $ curl --request POST \
 --data '{"entities":["CarbonDioxide", "Methane"]}'
 ```
 {: .example-box-content .scroll}
- 
+
 {% endtab %}
- 
+
 {% endtabs %}
+
 </div>
  
 Response:
@@ -380,48 +325,32 @@ Response:
 
 ```json
 {
-  "data":
-  [
+  "data": [
     {
       "entity": "CarbonDioxide",
-      "triples":
-      {
-        "emittedThing":
-        {
-          "entities":
-          [
+      "triples": {
+        "emittedThing": {
+          "entities": [
             {
               "name": "CO2 Emissions Per Capita",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "Amount_Emissions_CarbonDioxide_PerCapita",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Annual Amount of Emissions: Biogenic Emission Source, Carbon Dioxide",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "Annual_Emissions_CarbonDioxide_Biogenic",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Carbon Dioxide",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "Annual_Emissions_CarbonDioxide_NonBiogenic",
               "provenanceId": "dc/d7tbsb1"
             },
             {
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "dc/pelkj2pkyww1",
               "provenanceId": "dc/6zzrcr2"
             }
@@ -431,96 +360,64 @@ Response:
     },
     {
       "entity": "Methane",
-      "triples":
-      {
-        "contaminant":
-        {
-          "entities":
-          [
+      "triples": {
+        "contaminant": {
+          "entities": [
             {
               "name": "Whether Atmosphere is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_Atmosphere",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether EPA_OtherContaminatedThing is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_EPAOtherContaminatedThing",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether GroundWater is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_GroundWater",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether LandfillGas is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_LandfillGas",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether Leachate is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_Leachate",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether SoilGas is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_SoilGas",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether Soil is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_Soil",
               "provenanceId": "dc/d7tbsb1"
             },
             {
               "name": "Whether SolidWaste is contaminated with Methane.",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "IsContaminated_Methane_SolidWaste",
               "provenanceId": "dc/d7tbsb1"
             }
           ]
         },
-        "emittedThing":
-        {
-          "entities":
-          [
+        "emittedThing": {
+          "entities": [
             {
               "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Methane",
-              "types":
-              [
-                "StatisticalVariable"
-              ],
+              "types": ["StatisticalVariable"],
               "dcid": "Annual_Emissions_Methane_NonBiogenic",
               "provenanceId": "dc/d7tbsb1"
             }

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -10,7 +10,7 @@ permalink: /api/rest/v1/bulk/triples
 
 # /v1/bulk/triples
 
-Get [triples](/glossary.html#triple) for multiple entities.
+Get [triples](/glossary.html#triple) for multiple nodes.
 
 Useful for finding local connections between nodes of the Data Commons knowledge
 graph.
@@ -32,7 +32,7 @@ graph.
 </div>
 
 <div id="GET-request" class="api-tabcontent api-signature">
-https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}?nodes={node_dcid_1}&nodes={node_dcid_2}&key={your_api_key}
 </div>
 
 <div id="POST-request" class="api-tabcontent api-signature">
@@ -44,7 +44,7 @@ X-API-Key: {your_api_key}
 
 JSON Data:
 {
-  "entities": [
+  "nodes": [
     "{value_1}",
     "{value_2}",
     ...
@@ -60,7 +60,7 @@ JSON Data:
 
 | Name                                                        | Description                                                                                                                                                                                                                                |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the entity provided. If `out`, returns triples with edges pointing _away_ from the entity provided. |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the node provided. If `out`, returns triples with edges pointing _away_ from the node provided. |
 {: .doc-table }
 
 ### Query Parameters
@@ -68,7 +68,7 @@ JSON Data:
 | Name                                                  | Type   | Description                                                                                                                                                     |
 | ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | key <br /> <required-tag>Required</required-tag>      | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the entities to query.                                                                                                          |
+| nodes <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the nodes to query.                                                                                                          |
 {: .doc-table }
 
 ## Response
@@ -80,16 +80,16 @@ The response looks like:
   "data":
   [
     {
-      "entity": "entity_dcid_1",
+      "node": "node_dcid_1",
       "triples":
       {
-        "property_of_entity":
+        "property_of_node":
         {
-          "entities":
+          "nodes":
           [
             {
-              "property_of_connected_node_1": "value",
-              "property_of_connected_node_2": "value",
+              "property_1": "value",
+              "property_2": "value",
               ...
             }, ...
           ]
@@ -98,16 +98,16 @@ The response looks like:
       }
     },
     {
-      "entity": "entity_dcid_2",
+      "node": "node_dcid_2",
       "triples":
       {
-        "property_of_entity":
+        "property_of_node":
         {
-          "entities":
+          "nodes":
           [
             {
-              "property_of_connected_node_1": "value",
-              "property_of_connected_node_2": "value",
+              "property_1": "value",
+              "property_2": "value",
               ...
             }, ...
           ]
@@ -123,13 +123,13 @@ The response looks like:
 
 | Name    | Type   | Description                                                                                                                                                                       |
 | ------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| entity  | string | [DCID](/glossary.html#dcid) of the entity queried.                                                                                                                                |
-| triples | object | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
+| node  | string | [DCID](/glossary.html#dcid) of the node queried.                                                                                                                                |
+| triples | object | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the node queried, and nodes connected to the queried node via those properties. |
 {: .doc-table}
 
 ## Examples
 
-### Example 1: Get outgoing triples for multiple entities.
+### Example 1: Get outgoing triples for multiple nodes.
 
 Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and
 methane (DCID: `Methane`), for edges going _away_ from those nodes.
@@ -144,7 +144,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/triples/out?entities=CarbonDioxide&entities=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+'https://api.datacommons.org/v1/bulk/triples/out?nodes=CarbonDioxide&nodes=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
 
@@ -159,7 +159,7 @@ Request:
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/triples/out \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities":["CarbonDioxide", "Methane"]}'
+--data '{"nodes":["CarbonDioxide", "Methane"]}'
 ```
 {: .example-box-content .scroll}
 
@@ -176,10 +176,10 @@ Response:
 {
   "data": [
     {
-      "entity": "CarbonDioxide",
+      "node": "CarbonDioxide",
       "triples": {
         "description": {
-          "entities": [
+          "nodes": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "A colorless gas consisting of a carbon atom covalently double bonded to two oxygen atoms."
@@ -187,7 +187,7 @@ Response:
           ]
         },
         "descriptionUrl": {
-          "entities": [
+          "nodes": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "https://en.wikipedia.org/wiki/Carbon_dioxide"
@@ -195,7 +195,7 @@ Response:
           ]
         },
         "name": {
-          "entities": [
+          "nodes": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "Carbon Dioxide"
@@ -207,7 +207,7 @@ Response:
           ]
         },
         "provenance": {
-          "entities": [
+          "nodes": [
             {
               "name": "https://datacommons.org",
               "types": ["Provenance"],
@@ -217,7 +217,7 @@ Response:
           ]
         },
         "typeOf": {
-          "entities": [
+          "nodes": [
             {
               "name": "GasType",
               "types": ["Class"],
@@ -235,10 +235,10 @@ Response:
       }
     },
     {
-      "entity": "Methane",
+      "node": "Methane",
       "triples": {
         "isProvisional": {
-          "entities": [
+          "nodes": [
             {
               "name": "True",
               "types": ["Boolean"],
@@ -248,7 +248,7 @@ Response:
           ]
         },
         "name": {
-          "entities": [
+          "nodes": [
             {
               "provenanceId": "dc/5l5zxr1",
               "value": "Methane"
@@ -256,7 +256,7 @@ Response:
           ]
         },
         "provenance": {
-          "entities": [
+          "nodes": [
             {
               "name": "https://datacommons.org",
               "types": ["Provenance"],
@@ -266,7 +266,7 @@ Response:
           ]
         },
         "typeOf": {
-          "entities": [
+          "nodes": [
             {
               "name": "ChemicalCompound",
               "types": ["Class"],
@@ -288,7 +288,7 @@ Response:
 ```
 {: .example-box-content .scroll}
 
-### Example 2: Get incoming triples for multiple entities.
+### Example 2: Get incoming triples for multiple nodes.
 
 Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and
 methane (DCID: `Methane`), for edges going _towards_ those nodes.
@@ -303,7 +303,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/triples/in?entities=geoId/51&entities=CarbonDioxide&entities=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+'https://api.datacommons.org/v1/bulk/triples/in?nodes=geoId/51&nodes=CarbonDioxide&nodes=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
 
@@ -318,7 +318,7 @@ Request:
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/triples/in \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities":["CarbonDioxide", "Methane"]}'
+--data '{"nodes":["CarbonDioxide", "Methane"]}'
 ```
 {: .example-box-content .scroll}
 
@@ -335,10 +335,10 @@ Response:
 {
   "data": [
     {
-      "entity": "CarbonDioxide",
+      "node": "CarbonDioxide",
       "triples": {
         "emittedThing": {
-          "entities": [
+          "nodes": [
             {
               "name": "CO2 Emissions Per Capita",
               "types": ["StatisticalVariable"],
@@ -367,10 +367,10 @@ Response:
       }
     },
     {
-      "entity": "Methane",
+      "node": "Methane",
       "triples": {
         "contaminant": {
-          "entities": [
+          "nodes": [
             {
               "name": "Whether Atmosphere is contaminated with Methane.",
               "types": ["StatisticalVariable"],
@@ -422,7 +422,7 @@ Response:
           ]
         },
         "emittedThing": {
-          "entities": [
+          "nodes": [
             {
               "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Methane",
               "types": ["StatisticalVariable"],

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -1,0 +1,534 @@
+---
+layout: default
+title: Triples
+parent: v1 REST
+grand_parent: API
+nav_exclude: true
+published: false
+permalink: /api/rest/v1/bulk/triples
+---
+
+# /v1/bulk/triples
+
+Get [triples](/glossary.html#triple) for multiple entities.
+
+Useful for finding local connections between nodes of the Data Commons knowledge graph.
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    For single queries with a simpler output, see the [simple version](/api/rest/v1/triples) of this endpoint.
+</div>
+ 
+
+## Request
+
+<div class="api-tab">
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">
+    GET Request
+  </button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">
+    POST Request
+  </button>
+</div> 
+
+<div id="GET-request" class="api-tabcontent api-signature">
+https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}?entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+</div>
+
+<div id="POST-request" class="api-tabcontent api-signature">
+URL:
+https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}
+
+Header:
+X-API-Key: {your_api_key}
+
+JSON Data:
+{
+  "entities": [
+    "{value_1}",
+    "{value_2}",
+    ...
+  ]
+}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+<script src="/assets/js/api-doc-tabs.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the entity provided. If `out`, returns triples with edges pointing _away_ from the entity provided. |
+{: .doc-table }
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | string | [DCIDs](/glossary.html#dcid) of the entities to query. |
+{: .doc-table }
+ 
+ 
+
+## Response
+
+ 
+The response looks like:
+ 
+```json
+{
+  "data":
+  [
+    {
+      "entity": "entity_dcid_1",
+      "triples":
+      {
+        "property_of_entity":
+        {
+          "entities":
+          [
+            {
+              "property_of_connected_node_1": "value",
+              "property_of_connected_node_2": "value",
+              ...
+            }, ...
+          ]
+        }, ...
+
+      }
+    },
+    {
+      "entity": "entity_dcid_2",
+      "triples":
+      {
+        "property_of_entity":
+        {
+          "entities":
+          [
+            {
+              "property_of_connected_node_1": "value",
+              "property_of_connected_node_2": "value",
+              ...
+            }, ...
+          ]
+        }, ...
+      }
+    }, ...
+  ]
+}
+```
+{: .response-signature .scroll}
+ 
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string   | [DCID](/glossary.html#dcid) of the entity queried. |
+| triples    | object   | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
+{: .doc-table}
+ 
+
+## Examples
+
+ 
+
+### Example 1: Get outgoing triples for multiple entities.
+
+Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and methane (DCID: `Methane`), for edges going _away_ from those nodes.
+
+<div>
+{% tabs example1 %}
+ 
+{% tab example1 GET Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request GET --url \
+'https://api.datacommons.org/v1/bulk/triples/out?entities=CarbonDioxide&entities=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+ 
+{% tab example1 POST Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request POST \
+--url https://api.datacommons.org/v1/bulk/triples/out \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities":["CarbonDioxide", "Methane"]}'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+{% endtabs %}
+</div>
+ 
+Response:
+{: .example-box-title}
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "CarbonDioxide",
+      "triples":
+      {
+        "description":
+        {
+          "entities":
+          [
+            {
+              "provenanceId": "dc/5l5zxr1",
+              "value": "A colorless gas consisting of a carbon atom covalently double bonded to two oxygen atoms."
+            }
+          ]
+        },
+        "descriptionUrl":
+        {
+          "entities":
+          [
+            {
+              "provenanceId": "dc/5l5zxr1",
+              "value": "https://en.wikipedia.org/wiki/Carbon_dioxide"
+            }
+          ]
+        },
+        "name":
+        {
+          "entities":
+          [
+            {
+              "provenanceId": "dc/5l5zxr1",
+              "value": "Carbon Dioxide"
+            },
+            {
+              "provenanceId": "dc/5l5zxr1",
+              "value": "CarbonDioxide"
+            }
+          ]
+        },
+        "provenance":
+        {
+          "entities":
+          [
+            {
+              "name": "https://datacommons.org",
+              "types":
+              [
+                "Provenance"
+              ],
+              "dcid": "dc/5l5zxr1",
+              "provenanceId": "dc/5l5zxr1"
+            }
+          ]
+        },
+        "typeOf":
+        {
+          "entities":
+          [
+            {
+              "name": "GasType",
+              "types":
+              [
+                "Class"
+              ],
+              "dcid": "GasType",
+              "provenanceId": "dc/5l5zxr1"
+            },
+            {
+              "name": "GreenhouseGas",
+              "types":
+              [
+                "Class"
+              ],
+              "dcid": "GreenhouseGas",
+              "provenanceId": "dc/5l5zxr1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "entity": "Methane",
+      "triples":
+      {
+        "isProvisional":
+        {
+          "entities":
+          [
+            {
+              "name": "True",
+              "types":
+              [
+                "Boolean"
+              ],
+              "dcid": "True",
+              "provenanceId": "dc/5l5zxr1"
+            }
+          ]
+        },
+        "name":
+        {
+          "entities":
+          [
+            {
+              "provenanceId": "dc/5l5zxr1",
+              "value": "Methane"
+            }
+          ]
+        },
+        "provenance":
+        {
+          "entities":
+          [
+            {
+              "name": "https://datacommons.org",
+              "types":
+              [
+                "Provenance"
+              ],
+              "dcid": "dc/5l5zxr1",
+              "provenanceId": "dc/5l5zxr1"
+            }
+          ]
+        },
+        "typeOf":
+        {
+          "entities":
+          [
+            {
+              "name": "ChemicalCompound",
+              "types":
+              [
+                "Class"
+              ],
+              "dcid": "ChemicalCompound",
+              "provenanceId": "dc/5l5zxr1"
+            },
+            {
+              "name": "GreenhouseGas",
+              "types":
+              [
+                "Class"
+              ],
+              "dcid": "GreenhouseGas",
+              "provenanceId": "dc/5l5zxr1"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}
+ 
+ 
+### Example 2: Get incoming triples for multiple entities.
+
+Get triples for the greenhouse gases carbon dioxide (DCID: `CarbonDioxide`) and methane (DCID: `Methane`), for edges going _towards_ those nodes.
+
+<div>
+{% tabs example1 %}
+ 
+{% tab example1 GET Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request GET --url \
+'https://api.datacommons.org/v1/bulk/triples/in?entities=geoId/51&entities=CarbonDioxide&entities=Methane&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+ 
+{% tab example1 POST Request %}
+ 
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request POST \
+--url https://api.datacommons.org/v1/bulk/triples/in \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities":["CarbonDioxide", "Methane"]}'
+```
+{: .example-box-content .scroll}
+ 
+{% endtab %}
+ 
+{% endtabs %}
+</div>
+ 
+Response:
+{: .example-box-title}
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "CarbonDioxide",
+      "triples":
+      {
+        "emittedThing":
+        {
+          "entities":
+          [
+            {
+              "name": "CO2 Emissions Per Capita",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "Amount_Emissions_CarbonDioxide_PerCapita",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Annual Amount of Emissions: Biogenic Emission Source, Carbon Dioxide",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "Annual_Emissions_CarbonDioxide_Biogenic",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Carbon Dioxide",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "Annual_Emissions_CarbonDioxide_NonBiogenic",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "dc/pelkj2pkyww1",
+              "provenanceId": "dc/6zzrcr2"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "entity": "Methane",
+      "triples":
+      {
+        "contaminant":
+        {
+          "entities":
+          [
+            {
+              "name": "Whether Atmosphere is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_Atmosphere",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether EPA_OtherContaminatedThing is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_EPAOtherContaminatedThing",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether GroundWater is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_GroundWater",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether LandfillGas is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_LandfillGas",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether Leachate is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_Leachate",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether SoilGas is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_SoilGas",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether Soil is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_Soil",
+              "provenanceId": "dc/d7tbsb1"
+            },
+            {
+              "name": "Whether SolidWaste is contaminated with Methane.",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "IsContaminated_Methane_SolidWaste",
+              "provenanceId": "dc/d7tbsb1"
+            }
+          ]
+        },
+        "emittedThing":
+        {
+          "entities":
+          [
+            {
+              "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Methane",
+              "types":
+              [
+                "StatisticalVariable"
+              ],
+              "dcid": "Annual_Emissions_Methane_NonBiogenic",
+              "provenanceId": "dc/d7tbsb1"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -39,9 +39,17 @@ https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}?entities={entity_dc
 URL:
 https://api.datacommons.org/v1/bulk/triples/{EDGE_DIRECTION}
 
-Header: X-API-Key: {your_api_key}
+Header:
+X-API-Key: {your_api_key}
 
-JSON Data: { "entities": [ "{value_1}", "{value_2}", ... ] }
+JSON Data:
+{
+  "entities": [
+    "{value_1}",
+    "{value_2}",
+    ...
+  ]
+}
 
 </div>
 

--- a/api/rest/v1/triples.md
+++ b/api/rest/v1/triples.md
@@ -17,7 +17,7 @@ graph.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
-    To query triples for multiple entities, see the [bulk version](/api/rest/v1/bulk/triples) of this endpoint.
+    To query triples for multiple nodes, see the [bulk version](/api/rest/v1/bulk/triples) of this endpoint.
 </div>
 
 ## Request
@@ -26,7 +26,7 @@ GET Request
 {: .api-header}
 
 <div class="api-signature">
-http://api.datacommons.org/v1/triples/{EDGE_DIRECTION}/{ENTITY_DCID}?key={api_key}
+http://api.datacommons.org/v1/triples/{EDGE_DIRECTION}/{NODE_DCID}?key={api_key}
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -35,8 +35,8 @@ http://api.datacommons.org/v1/triples/{EDGE_DIRECTION}/{ENTITY_DCID}?key={api_ke
 
 | Name                                                        | Description                                                                                                                                                                                                                                |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the entity provided. If `out`, returns triples with edges pointing _away_ from the entity provided. |
-| ENTITY_DCID <br /> <required-tag>Required</required-tag>    | [DCID](/glossary.html#dcid) of the entity to query.                                                                                                                                                                                        |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the node provided. If `out`, returns triples with edges pointing _away_ from the node provided. |
+| NODE_DCID <br /> <required-tag>Required</required-tag>    | [DCID](/glossary.html#dcid) of the node to query.                                                                                                                                                                                        |
 
 {: .doc-table }
 
@@ -55,13 +55,13 @@ The response looks like:
 {
   "triples":
   {
-    "property_describing_entity_queried_1":
+    "property_describing_node_queried_1":
     {
-      "entities":
+      "nodes":
       [
         {
-          "property_of_connected_node_1": "value",
-          "property_of_connected_node_2": "value",
+          "property_1": "value",
+          "property_2": "value",
           ...
         }, ...
       ]
@@ -75,7 +75,7 @@ The response looks like:
 
 | Name    | Type   | Description                                                                                                                                                                       |
 | ------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| triples | object | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
+| triples | object | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the node queried, and nodes connected to the queried node via those properties. |
 {: .doc-table}
 
 ## Examples
@@ -101,7 +101,7 @@ Response:
 {
   "triples": {
     "description": {
-      "entities": [
+      "nodes": [
         {
           "provenanceId": "dc/5l5zxr1",
           "value": "A colorless gas consisting of a carbon atom covalently double bonded to two oxygen atoms."
@@ -109,7 +109,7 @@ Response:
       ]
     },
     "descriptionUrl": {
-      "entities": [
+      "nodes": [
         {
           "provenanceId": "dc/5l5zxr1",
           "value": "https://en.wikipedia.org/wiki/Carbon_dioxide"
@@ -117,7 +117,7 @@ Response:
       ]
     },
     "name": {
-      "entities": [
+      "nodes": [
         {
           "provenanceId": "dc/5l5zxr1",
           "value": "Carbon Dioxide"
@@ -129,7 +129,7 @@ Response:
       ]
     },
     "provenance": {
-      "entities": [
+      "nodes": [
         {
           "name": "https://datacommons.org",
           "types": ["Provenance"],
@@ -139,7 +139,7 @@ Response:
       ]
     },
     "typeOf": {
-      "entities": [
+      "nodes": [
         {
           "name": "GasType",
           "types": ["Class"],
@@ -180,7 +180,7 @@ Response:
 {
   "triples": {
     "emittedThing": {
-      "entities": [
+      "nodes": [
         {
           "name": "CO2 Emissions Per Capita",
           "types": ["StatisticalVariable"],

--- a/api/rest/v1/triples.md
+++ b/api/rest/v1/triples.md
@@ -12,7 +12,8 @@ permalink: /api/rest/v1/triples
 
 Get a [triple](/glossary.html#triple).
 
-Useful for finding local connections between nodes of the Data Commons knowledge graph.
+Useful for finding local connections between nodes of the Data Commons knowledge
+graph.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
@@ -32,17 +33,18 @@ http://api.datacommons.org/v1/triples/{EDGE_DIRECTION}/{ENTITY_DCID}?key={api_ke
 
 ### Path Parameters
 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
+| Name                                                        | Description                                                                                                                                                                                                                                |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the entity provided. If `out`, returns triples with edges pointing _away_ from the entity provided. |
-| ENTITY_DCID <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query. |
+| ENTITY_DCID <br /> <required-tag>Required</required-tag>    | [DCID](/glossary.html#dcid) of the entity to query.                                                                                                                                                                                        |
+
 {: .doc-table }
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| Name                                             | Type   | Description                                                                                                                                                     |
+| ------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag> | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 {: .doc-table }
 
 ## Response
@@ -71,19 +73,21 @@ The response looks like:
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| triples    | object   | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
+| Name    | Type   | Description                                                                                                                                                                       |
+| ------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| triples | object | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
 {: .doc-table}
 
 ## Examples
 
 ### Example 1: Get triples of outgoing edges
 
-Get triples for the node representing Carbon Dioxide (DCID: `CarbonDioxide`), where edges point _away_ from the node for Carbon Dioxide.
+Get triples for the node representing Carbon Dioxide (DCID: `CarbonDioxide`),
+where edges point _away_ from the node for Carbon Dioxide.
 
 Request:
 {: .example-box-title}
+
 ```bash
   $ curl --request GET --url \
   'https://api.datacommons.org/v1/triples/out/CarbonDioxide&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
@@ -92,34 +96,28 @@ Request:
 
 Response:
 {: .example-box-title}
+
 ```json
 {
-  "triples":
-  {
-    "description":
-    {
-      "entities":
-      [
+  "triples": {
+    "description": {
+      "entities": [
         {
           "provenanceId": "dc/5l5zxr1",
           "value": "A colorless gas consisting of a carbon atom covalently double bonded to two oxygen atoms."
         }
       ]
     },
-    "descriptionUrl":
-    {
-      "entities":
-      [
+    "descriptionUrl": {
+      "entities": [
         {
           "provenanceId": "dc/5l5zxr1",
           "value": "https://en.wikipedia.org/wiki/Carbon_dioxide"
         }
       ]
     },
-    "name":
-    {
-      "entities":
-      [
+    "name": {
+      "entities": [
         {
           "provenanceId": "dc/5l5zxr1",
           "value": "Carbon Dioxide"
@@ -130,40 +128,27 @@ Response:
         }
       ]
     },
-    "provenance":
-    {
-      "entities":
-      [
+    "provenance": {
+      "entities": [
         {
           "name": "https://datacommons.org",
-          "types":
-          [
-            "Provenance"
-          ],
+          "types": ["Provenance"],
           "dcid": "dc/5l5zxr1",
           "provenanceId": "dc/5l5zxr1"
         }
       ]
     },
-    "typeOf":
-    {
-      "entities":
-      [
+    "typeOf": {
+      "entities": [
         {
           "name": "GasType",
-          "types":
-          [
-            "Class"
-          ],
+          "types": ["Class"],
           "dcid": "GasType",
           "provenanceId": "dc/5l5zxr1"
         },
         {
           "name": "GreenhouseGas",
-          "types":
-          [
-            "Class"
-          ],
+          "types": ["Class"],
           "dcid": "GreenhouseGas",
           "provenanceId": "dc/5l5zxr1"
         }
@@ -176,10 +161,12 @@ Response:
 
 ### Example 2: Get triples of incoming edges
 
-Get triples for the node representing Carbon Dioxide (DCID: `CarbonDioxide`), where edges point _towards_ the node Carbon Dioxide. 
+Get triples for the node representing Carbon Dioxide (DCID: `CarbonDioxide`),
+where edges point _towards_ the node Carbon Dioxide.
 
 Request:
 {: .example-box-title}
+
 ```bash
   $ curl --request GET --url \
   'https://api.datacommons.org/v1/triples/in/CarbonDioxide?query=value&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
@@ -188,46 +175,32 @@ Request:
 
 Response:
 {: .example-box-title}
+
 ```json
 {
-  "triples":
-  {
-    "emittedThing":
-    {
-      "entities":
-      [
+  "triples": {
+    "emittedThing": {
+      "entities": [
         {
           "name": "CO2 Emissions Per Capita",
-          "types":
-          [
-            "StatisticalVariable"
-          ],
+          "types": ["StatisticalVariable"],
           "dcid": "Amount_Emissions_CarbonDioxide_PerCapita",
           "provenanceId": "dc/d7tbsb1"
         },
         {
           "name": "Annual Amount of Emissions: Biogenic Emission Source, Carbon Dioxide",
-          "types":
-          [
-            "StatisticalVariable"
-          ],
+          "types": ["StatisticalVariable"],
           "dcid": "Annual_Emissions_CarbonDioxide_Biogenic",
           "provenanceId": "dc/d7tbsb1"
         },
         {
           "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Carbon Dioxide",
-          "types":
-          [
-            "StatisticalVariable"
-          ],
+          "types": ["StatisticalVariable"],
           "dcid": "Annual_Emissions_CarbonDioxide_NonBiogenic",
           "provenanceId": "dc/d7tbsb1"
         },
         {
-          "types":
-          [
-            "StatisticalVariable"
-          ],
+          "types": ["StatisticalVariable"],
           "dcid": "dc/pelkj2pkyww1",
           "provenanceId": "dc/6zzrcr2"
         }

--- a/api/rest/v1/triples.md
+++ b/api/rest/v1/triples.md
@@ -1,0 +1,239 @@
+---
+layout: default
+title: Triples
+nav_order: 7
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/triples
+---
+
+# /v1/triples
+
+Get a [triple](/glossary.html#triple).
+
+Useful for finding local connections between nodes of the Data Commons knowledge graph.
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    To query triples for multiple entities, see the [bulk version](/api/rest/v1/bulk/triples) of this endpoint.
+</div>
+
+## Request
+
+GET Request
+{: .api-header}
+
+<div class="api-signature">
+http://api.datacommons.org/v1/triples/{EDGE_DIRECTION}/{ENTITY_DCID}?key={api_key}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. Denotes direction of edges to get triples for. <br /><br />If `in`, returns triples with edges pointing _toward_ the entity provided. If `out`, returns triples with edges pointing _away_ from the entity provided. |
+| ENTITY_DCID <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query. |
+{: .doc-table }
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+{: .doc-table }
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "triples":
+  {
+    "property_describing_entity_queried_1":
+    {
+      "entities":
+      [
+        {
+          "property_of_connected_node_1": "value",
+          "property_of_connected_node_2": "value",
+          ...
+        }, ...
+      ]
+    }, ...
+  }
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| triples    | object   | A nested JSON object containing [DCIDs](/glossary.html#dcid) of both properties that describe the entity queried, and nodes connected to the queried entity via those properties. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Get triples of outgoing edges
+
+Get triples for the node representing Carbon Dioxide (DCID: `CarbonDioxide`), where edges point _away_ from the node for Carbon Dioxide.
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/triples/out/CarbonDioxide&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "triples":
+  {
+    "description":
+    {
+      "entities":
+      [
+        {
+          "provenanceId": "dc/5l5zxr1",
+          "value": "A colorless gas consisting of a carbon atom covalently double bonded to two oxygen atoms."
+        }
+      ]
+    },
+    "descriptionUrl":
+    {
+      "entities":
+      [
+        {
+          "provenanceId": "dc/5l5zxr1",
+          "value": "https://en.wikipedia.org/wiki/Carbon_dioxide"
+        }
+      ]
+    },
+    "name":
+    {
+      "entities":
+      [
+        {
+          "provenanceId": "dc/5l5zxr1",
+          "value": "Carbon Dioxide"
+        },
+        {
+          "provenanceId": "dc/5l5zxr1",
+          "value": "CarbonDioxide"
+        }
+      ]
+    },
+    "provenance":
+    {
+      "entities":
+      [
+        {
+          "name": "https://datacommons.org",
+          "types":
+          [
+            "Provenance"
+          ],
+          "dcid": "dc/5l5zxr1",
+          "provenanceId": "dc/5l5zxr1"
+        }
+      ]
+    },
+    "typeOf":
+    {
+      "entities":
+      [
+        {
+          "name": "GasType",
+          "types":
+          [
+            "Class"
+          ],
+          "dcid": "GasType",
+          "provenanceId": "dc/5l5zxr1"
+        },
+        {
+          "name": "GreenhouseGas",
+          "types":
+          [
+            "Class"
+          ],
+          "dcid": "GreenhouseGas",
+          "provenanceId": "dc/5l5zxr1"
+        }
+      ]
+    }
+  }
+}
+```
+{: .example-box-content .scroll}
+
+### Example 2: Get triples of incoming edges
+
+Get triples for the node representing Carbon Dioxide (DCID: `CarbonDioxide`), where edges point _towards_ the node Carbon Dioxide. 
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/triples/in/CarbonDioxide?query=value&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "triples":
+  {
+    "emittedThing":
+    {
+      "entities":
+      [
+        {
+          "name": "CO2 Emissions Per Capita",
+          "types":
+          [
+            "StatisticalVariable"
+          ],
+          "dcid": "Amount_Emissions_CarbonDioxide_PerCapita",
+          "provenanceId": "dc/d7tbsb1"
+        },
+        {
+          "name": "Annual Amount of Emissions: Biogenic Emission Source, Carbon Dioxide",
+          "types":
+          [
+            "StatisticalVariable"
+          ],
+          "dcid": "Annual_Emissions_CarbonDioxide_Biogenic",
+          "provenanceId": "dc/d7tbsb1"
+        },
+        {
+          "name": "Annual Amount of Emissions: Non Biogenic Emission Source, Carbon Dioxide",
+          "types":
+          [
+            "StatisticalVariable"
+          ],
+          "dcid": "Annual_Emissions_CarbonDioxide_NonBiogenic",
+          "provenanceId": "dc/d7tbsb1"
+        },
+        {
+          "types":
+          [
+            "StatisticalVariable"
+          ],
+          "dcid": "dc/pelkj2pkyww1",
+          "provenanceId": "dc/6zzrcr2"
+        }
+      ]
+    }
+  }
+}
+```
+{: .example-box-content .scroll}


### PR DESCRIPTION
This PR adds the following v1 REST API documentation pages:
* /v1/triples
* /v1/bulk/triples