### PR TITLE
[v1 API Docs] add */property/values pages

### DIFF
--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -10,11 +10,11 @@ permalink: /api/rest/v1/bulk/property/values
 
 # /v1/bulk/property/values
 
-Get the values of a [property](/glossary.html#property) for multiple entities.
+Get the values of a [property](/glossary.html#property) for multiple nodes.
 
 Data Commons represents properties as labels of directed edges between nodes,
 where the successor node is a value of the property. Thus, this endpoint returns
-nodes connected to the queried entity via the property queried.
+nodes connected to the queried node via the property queried.
 
 _Note: If you want to query values for the property `containedInPlace`, consider
 using
@@ -23,7 +23,7 @@ instead._
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
-    To get a list of properties available for an entity, see [/v1/bulk/properties](/api/rest/v1/bulk/properties).<br />
+    To get a list of properties available for an node, see [/v1/bulk/properties](/api/rest/v1/bulk/properties).<br />
     For single queries with a simpler output, see the [simple version](/api/rest/v1/property/values) of this endpoint.
 </div>
 
@@ -35,7 +35,7 @@ instead._
 </div>
 
 <div id="GET-request" class="api-tabcontent api-signature">
-https://api.datacommons.org/v1/bulk/property/values/{EDGE_DIRECTION}?property={property_dcid}&entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+https://api.datacommons.org/v1/bulk/property/values/{EDGE_DIRECTION}?property={property_dcid}&nodes={node_dcid_1}&nodes={node_dcid_2}&key={your_api_key}
 </div>
 
 <div id="POST-request" class="api-tabcontent api-signature">
@@ -48,9 +48,9 @@ X-API-Key: {your_api_key}
 JSON Data:
 { 
   "property": "property_dcid",
-  "entities": [
-    "{entity_dcid_1}",
-    "{entity_dcid_2}",
+  "nodes": [
+    "{node_dcid_1}",
+    "{node_dcid_2}",
     ...
   ]
 }
@@ -64,7 +64,7 @@ JSON Data:
 
 | Name                                                        | Description                                                                                                                                                                      |
 | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried entity is a property value. If `out`, returns values of properties describing the entity queried. |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried node is a property value. If `out`, returns values of properties describing the node queried. |
 {: .doc-table }
 
 ### Query Parameters
@@ -72,7 +72,7 @@ JSON Data:
 | Name                                                  | Type   | Description                                                                                                                                                     |
 | ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | key <br /> <required-tag>Required</required-tag>      | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| entities <br /> <required-tag>Required</required-tag> | list   | [DCIDs](/glossary.html#dcid) of the entitis to query.                                                                                                           |
+| nodes <br /> <required-tag>Required</required-tag> | list   | [DCIDs](/glossary.html#dcid) of the entitis to query.                                                                                                           |
 | property <br /> <required-tag>Required</required-tag> | string | [DCID](/glossary.html#dcid) of the property to query.                                                                                                           |
 {: .doc-table }
 
@@ -85,33 +85,33 @@ The response looks like:
   "data":
   [
     {
-      "entity": "connected_entity_dcid",
+      "node": "connected_node_dcid",
       "values":
       [
         {
-          "property_of_connected_entity_1": "value",
-          "property_of_connected_entity_1": "value",
+          "property_of_connected_node_1": "value",
+          "property_of_connected_node_1": "value",
           ...
         },
         {
-          "property_of_connected_entity_2": "value",
-          "property_of_connected_entity_2": "value",
+          "property_of_connected_node_2": "value",
+          "property_of_connected_node_2": "value",
           ...
         }
       ]
     },
     {
-      "entity": "connected_entity_dcid_2",
+      "node": "connected_node_dcid_2",
       "values":
       [
         {
-          "property_of_connected_entity_1": "value",
-          "property_of_connected_entity_1": "value",
+          "property_of_connected_node_1": "value",
+          "property_of_connected_node_1": "value",
           ...
         },
         {
-          "property_of_connected_entity_2": "value",
-          "property_of_connected_entity_2": "value",
+          "property_of_connected_node_2": "value",
+          "property_of_connected_node_2": "value",
           ...
         }
       ]
@@ -125,13 +125,13 @@ The response looks like:
 
 | Name   | Type   | Description                                        |
 | ------ | ------ | -------------------------------------------------- |
-| entity | string | [DCID](/glossary.html#dcid) of the entity queried. |
+| node | string | [DCID](/glossary.html#dcid) of the node queried. |
 | values | list   | list of nodes connected by the property queried.   |
 {: .doc-table}
 
 ## Examples
 
-### Example 1: Get property values for multiple entities
+### Example 1: Get property values for multiple nodes
 
 Get the names (property: `name`) of nodes with DCIDs `wikidataId/Q27119`,
 `wikidataId/Q27116`, and `wikidataId/Q21181`.
@@ -146,7 +146,7 @@ Request:
 
 ```bash
 $ curl --request GET --url \
-'https://api.datacommons.org/v1/bulk/property/values/out?property=name&entities=wikidataId/Q27119&entities=wikidataId/Q27116&entities=wikidataId/Q21181&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+'https://api.datacommons.org/v1/bulk/property/values/out?property=name&nodes=wikidataId/Q27119&nodes=wikidataId/Q27116&nodes=wikidataId/Q21181&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
 ```
 {: .example-box-content .scroll}
 
@@ -161,7 +161,7 @@ Request:
 $ curl --request POST \
 --url https://api.datacommons.org/v1/bulk/property/values/out \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities":["wikidataId/Q27119", "wikidataId/Q27116", "wikidataId/Q21181"], "property":"name"}'
+--data '{"nodes":["wikidataId/Q27119", "wikidataId/Q27116", "wikidataId/Q21181"], "property":"name"}'
 ```
 {: .example-box-content .scroll}
 
@@ -178,7 +178,7 @@ Response:
 {
   "data": [
     {
-      "entity": "wikidataId/Q27119",
+      "node": "wikidataId/Q27119",
       "values": [
         {
           "provenanceId": "dc/5n63hr1",
@@ -187,7 +187,7 @@ Response:
       ]
     },
     {
-      "entity": "wikidataId/Q27116",
+      "node": "wikidataId/Q27116",
       "values": [
         {
           "provenanceId": "dc/5n63hr1",
@@ -196,7 +196,7 @@ Response:
       ]
     },
     {
-      "entity": "wikidataId/Q21181",
+      "node": "wikidataId/Q21181",
       "values": [
         {
           "provenanceId": "dc/5n63hr1",

--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -12,9 +12,14 @@ permalink: /api/rest/v1/bulk/property/values
 
 Get the values of a [property](/glossary.html#property) for multiple entities.
 
-Data Commons represents properties as labels of directed edges between nodes, where the successor node is a value of the property. Thus, this endpoint returns nodes connected to the queried entity via the property queried.
+Data Commons represents properties as labels of directed edges between nodes,
+where the successor node is a value of the property. Thus, this endpoint returns
+nodes connected to the queried entity via the property queried.
 
-_Note: If you want to query values for the property `containedInPlace`, consider using [/v1/bulk/property/values/linked](/api/rest/v1/bulk/property/values/linked) instead._
+_Note: If you want to query values for the property `containedInPlace`, consider
+using
+[/v1/bulk/property/values/linked](/api/rest/v1/bulk/property/values/linked)
+instead._
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
@@ -41,7 +46,7 @@ Header:
 X-API-Key: {your_api_key}
 
 JSON Data:
-{
+{ 
   "property": "property_dcid",
   "entities": [
     "{entity_dcid_1}",
@@ -49,6 +54,7 @@ JSON Data:
     ...
   ]
 }
+
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -56,18 +62,18 @@ JSON Data:
 
 ### Path Parameters
 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
+| Name                                                        | Description                                                                                                                                                                      |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried entity is a property value. If `out`, returns values of properties describing the entity queried. |
 {: .doc-table }
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
-| entities <br /> <required-tag>Required</required-tag> | list | [DCIDs](/glossary.html#dcid) of the entitis to query.|
-| property <br /> <required-tag>Required</required-tag> | string | [DCID](/glossary.html#dcid) of the property to query. |
+| Name                                                  | Type   | Description                                                                                                                                                     |
+| ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag>      | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | list   | [DCIDs](/glossary.html#dcid) of the entitis to query.                                                                                                           |
+| property <br /> <required-tag>Required</required-tag> | string | [DCID](/glossary.html#dcid) of the property to query.                                                                                                           |
 {: .doc-table }
 
 ## Response
@@ -117,17 +123,18 @@ The response looks like:
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| entity   | string | [DCID](/glossary.html#dcid) of the entity queried. |
-| values   | list   | list of nodes connected by the property queried. |
+| Name   | Type   | Description                                        |
+| ------ | ------ | -------------------------------------------------- |
+| entity | string | [DCID](/glossary.html#dcid) of the entity queried. |
+| values | list   | list of nodes connected by the property queried.   |
 {: .doc-table}
 
 ## Examples
 
 ### Example 1: Get property values for multiple entities
 
-Get the names (property: `name`) of nodes with DCIDs `wikidataId/Q27119`, `wikidataId/Q27116`, and `wikidataId/Q21181`.
+Get the names (property: `name`) of nodes with DCIDs `wikidataId/Q27119`,
+`wikidataId/Q27116`, and `wikidataId/Q21181`.
 
 <div>
 {% tabs example1 %}
@@ -161,6 +168,7 @@ $ curl --request POST \
 {% endtab %}
 
 {% endtabs %}
+
 </div>
 
 Response:
@@ -168,12 +176,10 @@ Response:
 
 ```json
 {
-  "data":
-  [
+  "data": [
     {
       "entity": "wikidataId/Q27119",
-      "values":
-      [
+      "values": [
         {
           "provenanceId": "dc/5n63hr1",
           "value": "Kolding"
@@ -182,8 +188,7 @@ Response:
     },
     {
       "entity": "wikidataId/Q27116",
-      "values":
-      [
+      "values": [
         {
           "provenanceId": "dc/5n63hr1",
           "value": "Vejle"
@@ -192,8 +197,7 @@ Response:
     },
     {
       "entity": "wikidataId/Q21181",
-      "values":
-      [
+      "values": [
         {
           "provenanceId": "dc/5n63hr1",
           "value": "Fredericia"

--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -1,0 +1,206 @@
+---
+layout: default
+title: Property Values
+nav_exclude: true
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/bulk/property/values
+---
+
+# /v1/bulk/property/values
+
+Get the values of a [property](/glossary.html#property) for multiple entities.
+
+Data Commons represents properties as labels of directed edges between nodes, where the successor node is a value of the property. Thus, this endpoint returns nodes connected to the queried entity via the property queried.
+
+_Note: If you want to query values for the property `containedInPlace`, consider using [/v1/bulk/property/values/linked](/api/rest/v1/bulk/property/values/linked) instead._
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    To get a list of properties available for an entity, see [/v1/bulk/properties](/api/rest/v1/bulk/properties).<br />
+    For single queries with a simpler output, see the [simple version](/api/rest/v1/property/values) of this endpoint.
+</div>
+
+## Request
+
+<div class="api-tab">
+  <button id="get-button" class="api-tablink" onclick="openTab(event, 'GET-request')">GET Request</button>
+  <button id="post-button" class="api-tablink" onclick="openTab(event, 'POST-request')">POST Request</button>
+</div>
+
+<div id="GET-request" class="api-tabcontent api-signature">
+https://api.datacommons.org/v1/bulk/property/values/{EDGE_DIRECTION}?property={property_dcid}&entities={entity_dcid_1}&entities={entity_dcid_2}&key={your_api_key}
+</div>
+
+<div id="POST-request" class="api-tabcontent api-signature">
+URL:
+https://api.datacommons.org/v1/bulk/property/values/{EDGE_DIRECTION}
+
+Header:
+X-API-Key: {your_api_key}
+
+JSON Data:
+{
+  "property": "property_dcid",
+  "entities": [
+    "{entity_dcid_1}",
+    "{entity_dcid_2}",
+    ...
+  ]
+}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+<script src="/assets/js/api-doc-tabs.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried entity is a property value. If `out`, returns values of properties describing the entity queried. |
+{: .doc-table }
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| entities <br /> <required-tag>Required</required-tag> | list | [DCIDs](/glossary.html#dcid) of the entitis to query.|
+| property <br /> <required-tag>Required</required-tag> | string | [DCID](/glossary.html#dcid) of the property to query. |
+{: .doc-table }
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "connected_entity_dcid",
+      "values":
+      [
+        {
+          "property_of_connected_entity_1": "value",
+          "property_of_connected_entity_1": "value",
+          ...
+        },
+        {
+          "property_of_connected_entity_2": "value",
+          "property_of_connected_entity_2": "value",
+          ...
+        }
+      ]
+    },
+    {
+      "entity": "connected_entity_dcid_2",
+      "values":
+      [
+        {
+          "property_of_connected_entity_1": "value",
+          "property_of_connected_entity_1": "value",
+          ...
+        },
+        {
+          "property_of_connected_entity_2": "value",
+          "property_of_connected_entity_2": "value",
+          ...
+        }
+      ]
+    }, ...
+  ]
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| entity   | string | [DCID](/glossary.html#dcid) of the entity queried. |
+| values   | list   | list of nodes connected by the property queried. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Get property values for multiple entities
+
+Get the names (property: `name`) of nodes with DCIDs `wikidataId/Q27119`, `wikidataId/Q27116`, and `wikidataId/Q21181`.
+
+<div>
+{% tabs example1 %}
+
+{% tab example1 GET Request %}
+
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request GET --url \
+'https://api.datacommons.org/v1/bulk/property/values/out?property=name&entities=wikidataId/Q27119&entities=wikidataId/Q27116&entities=wikidataId/Q21181&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+
+{% endtab %}
+
+{% tab example1 POST Request %}
+
+Request:
+{: .example-box-title}
+
+```bash
+$ curl --request POST \
+--url https://api.datacommons.org/v1/bulk/property/values/out \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities":["wikidataId/Q27119", "wikidataId/Q27116", "wikidataId/Q21181"], "property":"name"}'
+```
+{: .example-box-content .scroll}
+
+{% endtab %}
+
+{% endtabs %}
+</div>
+
+Response:
+{: .example-box-title}
+
+```json
+{
+  "data":
+  [
+    {
+      "entity": "wikidataId/Q27119",
+      "values":
+      [
+        {
+          "provenanceId": "dc/5n63hr1",
+          "value": "Kolding"
+        }
+      ]
+    },
+    {
+      "entity": "wikidataId/Q27116",
+      "values":
+      [
+        {
+          "provenanceId": "dc/5n63hr1",
+          "value": "Vejle"
+        }
+      ]
+    },
+    {
+      "entity": "wikidataId/Q21181",
+      "values":
+      [
+        {
+          "provenanceId": "dc/5n63hr1",
+          "value": "Fredericia"
+        }
+      ]
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}

--- a/api/rest/v1/property_values.md
+++ b/api/rest/v1/property_values.md
@@ -1,0 +1,164 @@
+---
+layout: default
+title: Property Values
+nav_order: 6
+parent: v1 REST
+grand_parent: API
+published: false
+permalink: /api/rest/v1/property/values
+---
+
+# /v1/property/values
+
+Get the values of a [property](/glossary.html#property) for a specific entity.
+
+Data Commons represents properties as labels of directed edges between nodes, where the successor node is a value of the property. Thus, this endpoint returns nodes connected to the queried entity via the property queried.
+
+_Note: If you want to query values for the property `containedInPlace`, consider using [/v1/property/values/linked](/api/rest/v1/property/values/linked) instead._
+
+<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+    <span class="material-icons md-16">info </span><b>See Also:</b><br />
+    To get a list of properties available for an entity, see [/v1/properties](/api/rest/v1/properties).<br />
+    To query multiple entites or properties, see the [bulk version](/api/rest/v1/bulk/property/values) of this endpoint.
+</div>
+
+## Request
+
+GET Request
+{: .api-header}
+
+<div class="api-signature">
+http://api.datacommons.org/v1/property/values/{EDGE_DIRECTION}/{ENTITY}/{PROPERTY}?key={your_api_key}
+</div>
+
+<script src="/assets/js/syntax_highlighting.js"></script>
+
+### Path Parameters
+
+| Name                                                | Description                   |
+| --------------------------------------------------- | ----------------------------- |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried entity is a property value. If `out`, returns values of properties describing the entity queried. |
+| ENTITY <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query.|
+| PROPERTY <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the property to query. |
+{: .doc-table }
+
+### Query Parameters
+
+| Name                                               | Type | Description               |
+| -------------------------------------------------- | ---- | ------------------------- |
+| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+{: .doc-table }
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "values":
+  [
+    {
+      "property_1_of_connected_node": "value",
+      "property_2_of_connected_node": "value",
+      ...
+    }, ...
+  ]
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name     | Type   | Description                |
+| -------- | ------ | -------------------------- |
+| values    | object   | values of the property queried, for the entity queried. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Get the value of a property for an entity
+
+Get the name of the node with DCID `geoId/sch3620580` by querying the property `name`.
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/property/values/out/geoId/sch3620580/name&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "values":
+  [
+    {
+      "provenanceId": "dc/sm3m2w3",
+      "value": "New York City Department Of Education"
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}
+
+### Example 2: Get the nodes that have the queried entity as a property value
+
+Get a list of natural disasters in Madagascar (DCID: `country/MDG`) by querying the property `affectedPlace`.
+
+Request:
+{: .example-box-title}
+```bash
+  $ curl --request GET --url \
+  'https://api.datacommons.org/v1/property/values/in/country/MDG/affectedPlace&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+```json
+{
+  "values":
+  [
+    {
+      "name": "Unnamed SouthIndian Cyclone (1912324S11066)",
+      "types":
+      [
+        "CycloneEvent"
+      ],
+      "dcid": "cyclone/ibtracs_1912324S11066",
+      "provenanceId": "dc/xwq0y5"
+    },
+    {
+      "name": "Unnamed SouthIndian Cyclone (1913022S12053)",
+      "types":
+      [
+        "CycloneEvent"
+      ],
+      "dcid": "cyclone/ibtracs_1913022S12053",
+      "provenanceId": "dc/xwq0y5"
+    },
+    < ... output  truncated for brevity ... >
+    {
+      "name": "32 km SSE of Maroantsetra, Madagascar",
+      "types":
+      [
+        "EarthquakeEvent"
+      ],
+      "dcid": "earthquake/usp000h6zw",
+      "provenanceId": "dc/xz8ndk3"
+    },
+    {
+      "name": "23 km ENE of Amparafaravola, Madagascar",
+      "types":
+      [
+        "EarthquakeEvent"
+      ],
+      "dcid": "earthquake/usp000jgbb",
+      "provenanceId": "dc/xz8ndk3"
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}

--- a/api/rest/v1/property_values.md
+++ b/api/rest/v1/property_values.md
@@ -12,9 +12,13 @@ permalink: /api/rest/v1/property/values
 
 Get the values of a [property](/glossary.html#property) for a specific entity.
 
-Data Commons represents properties as labels of directed edges between nodes, where the successor node is a value of the property. Thus, this endpoint returns nodes connected to the queried entity via the property queried.
+Data Commons represents properties as labels of directed edges between nodes,
+where the successor node is a value of the property. Thus, this endpoint returns
+nodes connected to the queried entity via the property queried.
 
-_Note: If you want to query values for the property `containedInPlace`, consider using [/v1/property/values/linked](/api/rest/v1/property/values/linked) instead._
+_Note: If you want to query values for the property `containedInPlace`, consider
+using [/v1/property/values/linked](/api/rest/v1/property/values/linked)
+instead._
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
@@ -35,18 +39,18 @@ http://api.datacommons.org/v1/property/values/{EDGE_DIRECTION}/{ENTITY}/{PROPERT
 
 ### Path Parameters
 
-| Name                                                | Description                   |
-| --------------------------------------------------- | ----------------------------- |
+| Name                                                        | Description                                                                                                                                                                      |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried entity is a property value. If `out`, returns values of properties describing the entity queried. |
-| ENTITY <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the entity to query.|
-| PROPERTY <br /> <required-tag>Required</required-tag> | [DCID](/glossary.html#dcid) of the property to query. |
+| ENTITY <br /> <required-tag>Required</required-tag>         | [DCID](/glossary.html#dcid) of the entity to query.                                                                                                                              |
+| PROPERTY <br /> <required-tag>Required</required-tag>       | [DCID](/glossary.html#dcid) of the property to query.                                                                                                                            |
 {: .doc-table }
 
 ### Query Parameters
 
-| Name                                               | Type | Description               |
-| -------------------------------------------------- | ---- | ------------------------- |
-| key <br /> <required-tag>Required</required-tag>   | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| Name                                             | Type   | Description                                                                                                                                                     |
+| ------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag> | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 {: .doc-table }
 
 ## Response
@@ -69,19 +73,21 @@ The response looks like:
 
 ### Response fields
 
-| Name     | Type   | Description                |
-| -------- | ------ | -------------------------- |
-| values    | object   | values of the property queried, for the entity queried. |
+| Name   | Type   | Description                                             |
+| ------ | ------ | ------------------------------------------------------- |
+| values | object | values of the property queried, for the entity queried. |
 {: .doc-table}
 
 ## Examples
 
 ### Example 1: Get the value of a property for an entity
 
-Get the name of the node with DCID `geoId/sch3620580` by querying the property `name`.
+Get the name of the node with DCID `geoId/sch3620580` by querying the property
+`name`.
 
 Request:
 {: .example-box-title}
+
 ```bash
   $ curl --request GET --url \
   'https://api.datacommons.org/v1/property/values/out/geoId/sch3620580/name&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
@@ -90,10 +96,10 @@ Request:
 
 Response:
 {: .example-box-title}
+
 ```json
 {
-  "values":
-  [
+  "values": [
     {
       "provenanceId": "dc/sm3m2w3",
       "value": "New York City Department Of Education"
@@ -105,10 +111,12 @@ Response:
 
 ### Example 2: Get the nodes that have the queried entity as a property value
 
-Get a list of natural disasters in Madagascar (DCID: `country/MDG`) by querying the property `affectedPlace`.
+Get a list of natural disasters in Madagascar (DCID: `country/MDG`) by querying
+the property `affectedPlace`.
 
 Request:
 {: .example-box-title}
+
 ```bash
   $ curl --request GET --url \
   'https://api.datacommons.org/v1/property/values/in/country/MDG/affectedPlace&key=AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI'
@@ -117,6 +125,7 @@ Request:
 
 Response:
 {: .example-box-title}
+
 ```json
 {
   "values":

--- a/api/rest/v1/property_values.md
+++ b/api/rest/v1/property_values.md
@@ -10,11 +10,11 @@ permalink: /api/rest/v1/property/values
 
 # /v1/property/values
 
-Get the values of a [property](/glossary.html#property) for a specific entity.
+Get the values of a [property](/glossary.html#property) for a specific node.
 
 Data Commons represents properties as labels of directed edges between nodes,
 where the successor node is a value of the property. Thus, this endpoint returns
-nodes connected to the queried entity via the property queried.
+nodes connected to the queried node via the property queried.
 
 _Note: If you want to query values for the property `containedInPlace`, consider
 using [/v1/property/values/linked](/api/rest/v1/property/values/linked)
@@ -22,7 +22,7 @@ instead._
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
-    To get a list of properties available for an entity, see [/v1/properties](/api/rest/v1/properties).<br />
+    To get a list of properties available for an node, see [/v1/properties](/api/rest/v1/properties).<br />
     To query multiple entites or properties, see the [bulk version](/api/rest/v1/bulk/property/values) of this endpoint.
 </div>
 
@@ -32,7 +32,7 @@ GET Request
 {: .api-header}
 
 <div class="api-signature">
-http://api.datacommons.org/v1/property/values/{EDGE_DIRECTION}/{ENTITY}/{PROPERTY}?key={your_api_key}
+http://api.datacommons.org/v1/property/values/{EDGE_DIRECTION}/{NODE}/{PROPERTY}?key={your_api_key}
 </div>
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -41,8 +41,8 @@ http://api.datacommons.org/v1/property/values/{EDGE_DIRECTION}/{ENTITY}/{PROPERT
 
 | Name                                                        | Description                                                                                                                                                                      |
 | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried entity is a property value. If `out`, returns values of properties describing the entity queried. |
-| ENTITY <br /> <required-tag>Required</required-tag>         | [DCID](/glossary.html#dcid) of the entity to query.                                                                                                                              |
+| EDGE_DIRECTION <br /> <required-tag>Required</required-tag> | One of `in` or `out`. <br /><br />If `in`, returns nodes for which the queried node is a property value. If `out`, returns values of properties describing the node queried. |
+| NODE <br /> <required-tag>Required</required-tag>         | [DCID](/glossary.html#dcid) of the node to query.                                                                                                                              |
 | PROPERTY <br /> <required-tag>Required</required-tag>       | [DCID](/glossary.html#dcid) of the property to query.                                                                                                                            |
 {: .doc-table }
 
@@ -75,12 +75,12 @@ The response looks like:
 
 | Name   | Type   | Description                                             |
 | ------ | ------ | ------------------------------------------------------- |
-| values | object | values of the property queried, for the entity queried. |
+| values | object | values of the property queried, for the node queried. |
 {: .doc-table}
 
 ## Examples
 
-### Example 1: Get the value of a property for an entity
+### Example 1: Get the value of a property for an node
 
 Get the name of the node with DCID `geoId/sch3620580` by querying the property
 `name`.
@@ -109,7 +109,7 @@ Response:
 ```
 {: .example-box-content .scroll}
 
-### Example 2: Get the nodes that have the queried entity as a property value
+### Example 2: Get the nodes that have the queried node as a property value
 
 Get a list of natural disasters in Madagascar (DCID: `country/MDG`) by querying
 the property `affectedPlace`.


### PR DESCRIPTION
Adds the following v1 REST API documentation pages:
* v1/property/values
* v1/bulk/property/values