### PR TITLE
[V1 API Docs] CSS Tweaks in response to feedback

### DIFF
--- a/_sass/api_documentation.scss
+++ b/_sass/api_documentation.scss
@@ -18,9 +18,8 @@ $shadow: drop-shadow(0 0 0.2em rgba(0, 0, 0, 0.1));
 
 %param-tag {
   border-radius: 4px;
-  font: bold 0.75em monospace;
-  letter-spacing: -1px;
-  padding: 2px 6px;
+  font: normal 0.85em monospace;
+  padding: 1px 6px;
   text-transform: uppercase;
 }
 
@@ -40,8 +39,13 @@ $shadow: drop-shadow(0 0 0.2em rgba(0, 0, 0, 0.1));
 
 %code-box {
   background: $code-background-color;
-  font: 0.8em monospace;
+  font: normal 0.9em monospace;
   line-height: 1.5;
+
+  // override red border around `...`
+  .err {
+    border: none;
+  }
 }
 
 /** "Required" and "Optional" labels for parameters */
@@ -65,8 +69,6 @@ bulk-tag {
   @extend %param-tag;
   background-color: $api-tag-green;
   color: white;
-  font-weight: normal;
-  letter-spacing: normal;
 }
 
 /** Custom syntax highlighting */
@@ -98,8 +100,7 @@ bulk-tag {
   filter: $shadow;
   background-color: $code-background-color;
   color: #0e84b5;
-  font-family: monospace;
-  font-size: 16px;
+  font: normal 0.9em monospace;
   overflow-wrap: break-word;
   padding: 30px;
   padding-top: 0;
@@ -217,4 +218,19 @@ bulk-tag {
       background-color: transparent;
     }
   }
+}
+
+/** Alerts and info boxes */
+
+.alert {
+  font-size: 1em;
+  color: black;
+}
+
+.exclamation-icon {
+  background: var(--dc-red-lite);
+  color: white;
+  font-size: 1em;
+  margin-right: 0.5em;
+  padding-right: 0;
 }

--- a/api/rest/v1/_rest_api_template.md
+++ b/api/rest/v1/_rest_api_template.md
@@ -14,7 +14,7 @@ One line summary of what it does.
 
 Longer details if necessary can go in a short paragraph here. This is where to document any particular nuances in behavior or to provide special notes for end users. If there’s any special Data Commons terminology to define (e.g. triples), that should be done here as well.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To do some other related, but different thing, see [/v1/other/end/point](https://docs.datacommons.org)
 </div>

--- a/api/rest/v1/_rest_bulk_api_template.md
+++ b/api/rest/v1/_rest_bulk_api_template.md
@@ -13,7 +13,7 @@ One line summary of what it does.
 
 Longer details if necessary can go in a short paragraph here. This is where to document any particular nuances in behavior or to provide special notes for end users. If there’s any special Data Commons terminology to define (e.g. triples), that should be done here as well.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To do some other related, but different thing, see [/v1/other/end/point](https://docs.datacommons.org)
 </div>

--- a/api/rest/v1/bulk_info_place.md
+++ b/api/rest/v1/bulk_info_place.md
@@ -16,12 +16,12 @@ Get basic information about multiple [places](/glossary.html#place).
 
 This API returns basic information on multiple places, given each of their DCIDs. The information provided is per place, and includes the place's name, type (city, state, country, etc.), as well as information on all parent places that contain the place queried.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
    For a rich, graphical exploration of places available in the Data Commons knowledge graph, take a look at the [Place Explorer](https://datacommons.org/place).
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To get information on a variable instead of a place, see [/v1/bulk/info/variable](/api/rest/v1/info/variable).<br />
     For querying a single variable and a simpler output, see the [simple version](/api/rest/v1/info/place) of this endpoint.

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -19,12 +19,12 @@ variable, and includes the number of entities with data on each variable, the
 minimum and maximum values observed, and the name and DCID of the top 3 entities
 with highest observed values for each variable.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
     <span class="material-icons md-16">info </span><b>Tip:</b><br />
     To explore variables available in the Data Commons knowledge graph, take a look at the [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To get information on a place instead of a variable, see [/v1/bulk/info/place](/api/rest/v1/info/place).<br />
     For querying a single variable and a simpler output, see the [simple version](/api/rest/v1/info/variable) of this endpoint.

--- a/api/rest/v1/bulk_info_variable_group.md
+++ b/api/rest/v1/bulk_info_variable_group.md
@@ -18,12 +18,12 @@ display name, a list of child variables with their information, a list of child 
 with their information and the number of descendent variables. If variable groups DCIDs are not provided, then
 all the variable group information will be retrieved.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
    Variable group is used in the statistical variable hierarchy UI widget as shown in [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For querying a single variable group and a simpler output, see the [simple version](/api/rest/v1/info/variable-group) of this endpoint.
 </div>

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -18,7 +18,7 @@ permalink: /api/rest/v1/bulk/observations/point
 Retrieve a specific observation at a set date from multiple variables for multiple entities.
  
  
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    To retrieve the entire series of observations, use [/v1/bulk/observations/series](/api/rest/v1/observations/series)<br />
    For single queries with a simpler output, see the [simple version](/api/rest/v1/observations/point) of this endpoint

--- a/api/rest/v1/bulk_observations_point_linked.md
+++ b/api/rest/v1/bulk_observations_point_linked.md
@@ -26,12 +26,12 @@ in South America (returning observations for Buenos Aires).
 This is useful for retrieving an observation for all places within an ancestor place. 
 For example, this could be getting the population of women in 2018 for all states in the United States.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Note:</b><br />
    Currently, this endpoint only supports the `containedInPlace` property and `Place` entities. Support for other properties and entity types will be added in the future.
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To get a single observation for a single place, see [/v1/observations/point](/api/rest/v1/observations/point).<br />
     To get a series of observations for all places within an ancestor place, see [/v1/bulk/observations/series/linked](/api/rest/v1/observations/series/linked).

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -14,7 +14,7 @@ permalink: /api/rest/v1/bulk/observations/series
 Retrieve a series of observations for multiple variables and entities.
  
  
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    To retrieve a single observation within a series, use [/v1/bulk/observations/point](/api/rest/v1/observations/point).<br />
    For single queries with a simpler output, see the [simple version](/api/rest/v1/observations/series) of this endpoint.

--- a/api/rest/v1/bulk_observations_series_linked.md
+++ b/api/rest/v1/bulk_observations_series_linked.md
@@ -26,12 +26,12 @@ in South America (returning observations for Buenos Aires).
 This is useful for retrieving observations for all places within an ancestor place.
 For example, this could be getting the population of women for all states in the United States.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Note:</b><br />
    Currently, this endpoint only supports the `containedInPlace` property and `Place` entities. Support for other properties and entity types will be added in the future.
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To get a series of observations for a single place, see [/v1/observations/series](/api/rest/v1/observations/series).<br />
     To get single observations for all places within an ancestor place, see [/v1/bulk/observations/point/linked](/api/rest/v1/observations/point/linked).

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -19,7 +19,7 @@ directed, so properties can either be labels for edges _towards_ or _away_ from
 the node. Outgoing edges correspond to properties of the node. Incoming edges
 denote that the node is the value of this property for some other node.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To the values of properties, see [/v1/bulk/property/values](/api/rest/v1/bulk/property/values).<br />
     To find connected edges and nodes, see [/v1/bulk/triples](/api/rest/v1/bulk/triples).<br />

--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -21,7 +21,7 @@ using
 [/v1/bulk/property/values/linked](/api/rest/v1/bulk/property/values/linked)
 instead._
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To get a list of properties available for an node, see [/v1/bulk/properties](/api/rest/v1/bulk/properties).<br />
     For single queries with a simpler output, see the [simple version](/api/rest/v1/property/values) of this endpoint.

--- a/api/rest/v1/bulk_property_values_linked.md
+++ b/api/rest/v1/bulk_property_values_linked.md
@@ -13,7 +13,7 @@ permalink: /api/rest/v1/bulk/property/values/in/linked
 Return property values for [properties](/glossary.html#property) that can be
 chained for multiple degrees in the knowledge graph.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Note:</b><br />
    This API currently only supports the `containedInPlace` property to fetch `Place` nodes. Support for more properties and node types will be added in the future.
 </div>
@@ -28,7 +28,7 @@ is also contained in South America. With this endpoint, you could query for
 countries in South America (returning Argentina) or for cities in South America
 (returning Buenos Aires).
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For single requests with a simpler output, see the [simple version](/api/rest/v1/property/values/in/linked) of this endpoint.
 </div>

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -15,7 +15,7 @@ Get [triples](/glossary.html#triple) for multiple nodes.
 Useful for finding local connections between nodes of the Data Commons knowledge
 graph.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For single queries with a simpler output, see the [simple version](/api/rest/v1/triples) of this endpoint.
 </div>

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -13,7 +13,7 @@ permalink: /api/rest/v1/bulk/variables
 Get all [variables](/glossary.html#variable) with data associated with a
 specific entity, for multiple entities.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For querying a single entity with simpler output, see the [simple version](/api/rest/v1/variables) of this endpoint.
 </div>

--- a/api/rest/v1/getting_started.md
+++ b/api/rest/v1/getting_started.md
@@ -107,8 +107,8 @@ curl -X POST \
 
 {: #authentication}
 
-<div markdown="span" class="alert alert-danger" role="alert" style="color:black; font-size: 0.8em">
-   <span class="material-icons md-16">priority_high</span><b>Important:</b><br />
+<div markdown="span" class="alert alert-danger" role="alert">
+   <span class="material-icons exclamation-icon">priority_high</span><b>IMPORTANT:</b><br />
    API keys are now required. To use the REST API, a valid API key must be included in all requests.
 </div>
 
@@ -152,7 +152,7 @@ curl -X POST \
 
 We've provided a trial API key for general public use. This key will let you try the API and make single requests.
 
-<div markdown="span" class="alert alert-secondary" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-secondary" role="alert">
    <b>Trial Key: </b>
    `AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI`
 </div>

--- a/api/rest/v1/info_place.md
+++ b/api/rest/v1/info_place.md
@@ -16,12 +16,12 @@ Get basic information about a [place](/glossary.html#place).
 
 This API returns basic information on a place, given the place's [DCID](/glossary.html#dcid). The information provided includes the place's name, type (city, state, country, etc.), as well as information on all parent places that contain the place queried.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
    For a rich, graphical exploration of places available in the Data Commons knowledge graph, take a look at the [Place Explorer](https://datacommons.org/place).
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    To get information on a variable instead of a place, see [/v1/info/variable](/api/rest/v1/info/variable).<br />
    For querying multiple places, see the [bulk version](/api/rest/v1/bulk/info/place) of this endpoint.

--- a/api/rest/v1/info_variable.md
+++ b/api/rest/v1/info_variable.md
@@ -19,12 +19,12 @@ value observed, and the name and DCID of the top 3 entities with highest
 observed values for that variable. The information is grouped by place type
 (country, state, county, etc.).
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
    To explore variables available in the Data Commons knowledge graph, take a look at the [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    To get information on a place instead of a variable, see [/v1/info/place](/api/rest/v1/info/place).<br />
    For querying multiple variables, see the [bulk version](/api/rest/v1/bulk/info/variable) of this endpoint.

--- a/api/rest/v1/info_variable_group.md
+++ b/api/rest/v1/info_variable_group.md
@@ -17,12 +17,12 @@ This API returns basic information of a variable group, given the variable group
 display name, a list of child variables with their information, a list of child variable groups
 with their information and the number of descendent variables.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Tip:</b><br />
    Variable group is used in the statistical variable hierarchy UI widget as shown in [Statistical Variable Explorer](https://datacommons.org/tools/statvar).
 </div>
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    For querying multiple variables groups, see the [bulk version](/api/rest/v1/bulk/info/variable-group) of this endpoint.
 </div>

--- a/api/rest/v1/observations_point.md
+++ b/api/rest/v1/observations_point.md
@@ -12,7 +12,7 @@ permalink: /api/rest/v1/observations/point
 
 Retrieve a specific observation at a set date from a variable for an entity.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    To retrieve the entire series of observations, use [/v1/observations/series](/api/rest/v1/observations/series)<br />
    For querying multiple variables or entities, see the [bulk version](/api/rest/v1/bulk/observations/point) of this endpoint.

--- a/api/rest/v1/observations_series.md
+++ b/api/rest/v1/observations_series.md
@@ -12,7 +12,7 @@ permalink: /api/rest/v1/observations/series
 
 Retrieve series of observations from a specific variable for an entity from the preferred facet.
  
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
    To retrieve a single observation in a series of values, use [/v1/observations/point](/api/rest/v1/observations/point) <br />For querying multiple variables or entities, see the [bulk version](/api/rest/v1/bulk/observations/series) of this endpoint.
 </div>

--- a/api/rest/v1/properties.md
+++ b/api/rest/v1/properties.md
@@ -18,7 +18,7 @@ directed, so properties can either be labels for edges _towards_ or _away_ from
 the node. Outgoing edges correspond to properties of the node. Incoming edges
 denote that the node is the value of this property for some other node.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To find all possible values of a specific property, see [/v1/property/values](/api/rest/v1/property/values).<br />
     To find connected edges and nodes, see [/v1/triples](/api/rest/v1/triples).<br />

--- a/api/rest/v1/property_values.md
+++ b/api/rest/v1/property_values.md
@@ -20,7 +20,7 @@ _Note: If you want to query values for the property `containedInPlace`, consider
 using [/v1/property/values/linked](/api/rest/v1/property/values/linked)
 instead._
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To get a list of properties available for an node, see [/v1/properties](/api/rest/v1/properties).<br />
     To query multiple entites or properties, see the [bulk version](/api/rest/v1/bulk/property/values) of this endpoint.

--- a/api/rest/v1/property_values_linked.md
+++ b/api/rest/v1/property_values_linked.md
@@ -13,7 +13,7 @@ permalink: /api/rest/v1/property/values/in/linked
 Return property values for [properties](/glossary.html#property) that can be
 chained for multiple degrees in the knowledge graph.
 
-<div markdown="span" class="alert alert-info" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Note:</b><br />
    This API currently only supports the `containedInPlace` property to fetch `Place` nodes. Support for more properties and node types will be added in the future.
 </div>
@@ -28,7 +28,7 @@ is also contained in South America. With this endpoint, you could query for
 countries in South America (returning Argentina) or for cities in South America
 (returning Buenos Aires).
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To query multiple entites or properties, see the [bulk version](/api/rest/v1/bulk/property/values/in/linked) of this endpoint.
 </div>

--- a/api/rest/v1/triples.md
+++ b/api/rest/v1/triples.md
@@ -15,7 +15,7 @@ Get a [triple](/glossary.html#triple).
 Useful for finding local connections between nodes of the Data Commons knowledge
 graph.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     To query triples for multiple nodes, see the [bulk version](/api/rest/v1/bulk/triples) of this endpoint.
 </div>

--- a/api/rest/v1/variables.md
+++ b/api/rest/v1/variables.md
@@ -12,7 +12,7 @@ permalink: /api/rest/v1/variables
 
 Get all [variables](/glossary.html#variable) with data associated with a specific entity.
 
-<div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
+<div markdown="span" class="alert alert-warning" role="alert">
     <span class="material-icons md-16">info </span><b>See Also:</b><br />
     For querying multiple entities, see the [bulk version](/api/rest/v1/bulk/variables) of this endpoint.
 </div>


### PR DESCRIPTION
This PR makes some minor changes to the CSS of the v1 API documentation pages in response to feedback from the team. These changes fix issue #250

The changes include:

1. Remove the red boxes in example code
Current: 
![image](https://user-images.githubusercontent.com/4034366/190019485-f1932ce4-3244-4904-9bb7-e101bf6240da.png)
Proposed: 
![image](https://user-images.githubusercontent.com/4034366/190019534-cb38e879-a68b-4653-8344-80f96075dbf1.png)

2. Increase text size of alert boxes
Current: 
![image](https://user-images.githubusercontent.com/4034366/190019345-5c726714-55d7-411b-8d44-a7cd0ebdd3bd.png)
Proposed: 
![image](https://user-images.githubusercontent.com/4034366/190019381-9e84ac36-a327-418a-b176-a2a8d73559c5.png)

3. Increase text size of code
Current:
![image](https://user-images.githubusercontent.com/4034366/190019240-0b19fbed-7542-4044-89b3-2a22ffeb1f7f.png)
Proposed: 
![image](https://user-images.githubusercontent.com/4034366/190019278-9404a628-04a5-47b5-94c2-5d61c07d14ab.png)

4. **Make 'required' tags larger and easier to read**
Current: 
 ![image](https://user-images.githubusercontent.com/4034366/190015139-9b907d45-10be-4538-90ec-c523b6f6feab.png)
Proposed: 
![image](https://user-images.githubusercontent.com/4034366/190015370-f04212e8-1df9-43eb-945d-17fcff9967fd.png)

5. **Make important alert more prominent**
Current:
![image](https://user-images.githubusercontent.com/4034366/190019043-18b552bd-177f-4f73-bce7-127e563a8e69.png)
Proposed:
![image](https://user-images.githubusercontent.com/4034366/190019065-e1cdfbb4-4346-49d5-bfb4-f6d54987949c.png)


