### PR TITLE
[v1 API Docs] Some quick wording/typo fixes

### DIFF
--- a/api/rest/v1/index.md
+++ b/api/rest/v1/index.md
@@ -32,7 +32,7 @@ https://api.datacommons.org
 
 ### Simple vs Bulk Query
 
-Some APIs have bulk version, designed for handling multiple queries at a time,
+Some APIs have a bulk version, designed for handling multiple queries at a time,
 with more detailed output. Bulk endpoints are tagged with <bulk-tag>bulk</bulk-tag> below.
 
 ### Local Graph Exploration

--- a/api/rest/v1/info_place.md
+++ b/api/rest/v1/info_place.md
@@ -92,7 +92,7 @@ The response looks like:
 
 ## Examples
 
-### Example 1: Get information on a single variable
+### Example 1: Get information on a single place
 
 Get basic information about New York City (DCID: `geoId/3651000`).
 

--- a/api/rest/v1/observations_point.md
+++ b/api/rest/v1/observations_point.md
@@ -21,6 +21,7 @@ observation is returned.
 </div>
 
 ## Request
+
 GET Request
 {: .api-header}
 

--- a/api/rest/v1/observations_point.md
+++ b/api/rest/v1/observations_point.md
@@ -10,7 +10,9 @@ permalink: /api/rest/v1/observations/point
 
 # /v1/observations/point
 
-Retrieve a specific observation at a set date from a variable for an entity.
+Retrieve a specific observation at a set date from a variable for an entity from the
+[preferred facet](/glossary.html#preferred-facet). If no date is provided, the latest
+observation is returned.
 
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />

--- a/api/rest/v1/observations_series.md
+++ b/api/rest/v1/observations_series.md
@@ -10,11 +10,11 @@ permalink: /api/rest/v1/observations/series
  
 # /v1/observations/series
 
-Retrieve series of observations from a specific variable for an entity from the preferred facet.
+Retrieve series of observations from a specific variable for an entity from the [preferred facet](/glossary.html#preferred-facet).
  
 <div markdown="span" class="alert alert-warning" role="alert" style="color:black; font-size: 0.8em">
    <span class="material-icons md-16">info </span><b>See Also:</b><br />
-   To retrieve a single observation in a series of values, use [/v1/observations/point](/api/rest/v1/observations/point) <br />For querying multiple variables or entities, see the [bulk version](/api/rest/v1/bulk/observations/series) of this endpoint.
+   To retrieve a single observation in a series of values, use [/v1/observations/point](/api/rest/v1/observations/point) <br />For querying multiple variables or entities, or to get observations from other [facets](/glossary.html#facet), see the [bulk version](/api/rest/v1/bulk/observations/series) of this endpoint.
 </div>
  
 ## Request


### PR DESCRIPTION
This PR fixes fixes typos and some wording issues

Changes included:
* "Some APIs have _a_ bulk version" in index.md
* v1/info/place typo in example 1's header (issue #255)
* Add link to preferred facet's glossary entry in v1/observations/series (issue #253)
* Add more detail to the description of v1/observation/point (issue #252)