### PR TITLE
fix dropdown naming inconsistency

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
                 <a class="dropdown-item"
                   href="https://datacommons.org/tools/statvar">Statistical Variable Explorer</a>
                 <a class="dropdown-item"
-                  href="https://datacommons.org/tools/download">Download Tool</a>
+                  href="https://datacommons.org/tools/download">Data Download Tool</a>
               </div>
             </li>
             <li class="nav-item dropdown">


### PR DESCRIPTION
- the dropdown on website has the data download tool option as "Data Download Tool"