### PR TITLE
Fix broken link

### DIFF
--- a/api/rest/v1/property_values.md
+++ b/api/rest/v1/property_values.md
@@ -17,7 +17,7 @@ where the successor node is a value of the property. Thus, this endpoint returns
 nodes connected to the queried node via the property queried.
 
 _Note: If you want to query values for the property `containedInPlace`, consider
-using [/v1/property/values/linked](/api/rest/v1/property/values/linked)
+using [/v1/property/values/linked](/api/rest/v1/property/values/in/linked)
 instead._
 
 <div markdown="span" class="alert alert-warning" role="alert">


### PR DESCRIPTION
Current prod link goes to https://docs.datacommons.org/api/rest/v1/property/values/linked which is broken.