### PR TITLE
[v1 API Docs] Add page for v1/bulk/find/entities

### DIFF
--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -138,7 +138,7 @@ Response:
 
 ### Example 2: Find the DCID of places, using different descriptions
 
-This queries for the DCIDs of "_Cambridge_", "_Cambridge, MA_" and "_Cambridge, UK_". Notice how including "_MA_" or "_UK_" in the description helps disambiguate.
+This queries for the DCIDs of "_London_", "_London, ON_" and "_London, UK_". Notice how including "_ON_" or "_UK_" in the description helps disambiguate.
 
 Request:
 {: .example-box-title}
@@ -147,7 +147,7 @@ Request:
 curl -X POST \
 --url 'https://api.datacommons.org/v1/bulk/find/entities' \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities":[{"description": "Cambridge"},{"description": "Cambridge, MA"},{"description": "Cambridge, UK"}]}'
+--data '{"entities":[{"description": "London"},{"description": "London, ON"},{"description": "London, UK"}]}'
 ```
 {: .example-box-content .scroll}
 
@@ -158,16 +158,16 @@ Response:
 {
   "entities":[
     {
-      "description":"Cambridge",
-      "dcids":["wikidataId/Q350"]
+      "description":"London",
+      "dcids":["nuts/UKI"]
     },
     {
-      "description":"Cambridge, MA",
-      "dcids":["geoId/2511000"]
+      "description":"London, ON",
+      "dcids":["wikidataId/Q92561"]
     },
     {
-      "description":"Cambridge, UK",
-      "dcids":["wikidataId/Q350"]
+      "description":"London, UK",
+      "dcids":["nuts/UKI"]
     }
   ]
 }

--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -1,0 +1,147 @@
+---
+layout: default
+title: Find DCIDs
+parent: REST (v1)
+grand_parent: API
+nav_order: 1
+published: true
+permalink: /api/rest/v1/bulk/find/entities
+---
+
+# /v1/bulk/find/entities
+
+Find the DCID of an entity.
+
+Given the name of the entity, this endpoint searches for an entry in the Data Common knowledge graph and returns the DCID of the best match. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state).
+
+## Request
+
+POST Request
+{: .api-header}
+
+<div class="api-signature">
+URL:
+https://api.datacommons.org/v1/bulk/find/entities
+
+Header:
+X-API-Key: {your_api_key}
+
+JSON Data:
+{
+  "entities": [
+    {
+        "description": "{entity_name_1}",
+        "type": "{entity_type_1}"
+    },
+    {
+        "description": "{entity_name_2}",
+        "type": "{entity_type_3}"
+    },
+    ...
+  ]
+}
+</div>
+<script src="/assets/js/syntax_highlighting.js"></script>
+
+### Path Parameters
+
+There are no path parameters for this end point.
+
+### Query Parameters
+
+| Name                                                     | Type   | Description                                                                                                                                                     |
+| -------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| key <br /> <required-tag>Required</required-tag>         | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
+| description <br /> <required-tag>Required</required-tag> | string | The name of the entity.                                                                                                                                         |
+| type <br /> <optional-tag>Optional</optional-tag>        | string | The DCID of the entity's class. Common values are "Country", "State", "County", "City".                                                                         |
+{: .doc-table }
+
+## Response
+
+The response looks like:
+
+```json
+{
+  "entities": [
+    {
+      "description":"Description provided",
+      "type":"Type provided",
+      "dcids":["DCID"]
+    }
+  ]
+}
+```
+{: .response-signature .scroll}
+
+### Response fields
+
+| Name        | Type   | Description                                                                                            |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------------ |
+| description | string | The description you provided.                                                                          |
+| type        | string | The DCID of the entity's class, if provided.                                                           |
+| dcids       | list   | DCIDs matching the description you provided. If no matches are found, this field will not be returned. |
+{: .doc-table}
+
+## Examples
+
+### Example 1: Find the DCID of a place
+
+Find the DCID of "Georgia". Note that the DCID of the US state of Georgia is returned.
+
+Request:
+{: .example-box-title}
+
+```bash
+curl -X POST \
+--url 'https://api.datacommons.org/v1/bulk/find/entities' \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities": [{"description": "Georgia"}]}'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+
+```json
+{
+  "entities": [
+    {
+      "description": "Georgia",
+      "type": "Country",
+      "dcids": ["geoId/13"]
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}
+
+### Example 2: Find the DCID of a place that is a country
+
+Find the DCID of the country of Georgia. Here we specify "Country" for type to get the DCID of the country instead of the US state.
+
+Request:
+{: .example-box-title}
+
+```bash
+curl -X POST \
+--url 'https://api.datacommons.org/v1/bulk/find/entities' \
+--header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
+--data '{"entities": [{"description": "Georgia", "type": "Country"}]}'
+```
+{: .example-box-content .scroll}
+
+Response:
+{: .example-box-title}
+
+```json
+{
+  "entities": [
+    {
+      "description": "Georgia",
+      "type": "Country",
+      "dcids": ["country/GEO"]
+    }
+  ]
+}
+```
+{: .example-box-content .scroll}

--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -12,7 +12,7 @@ permalink: /api/rest/v1/bulk/find/entities
 
 Find the [DCIDs](/glossary.html#dcid) of multiple entities.
 
-Given the description of an entity, this endpoint searches for an entry in the Data Commons knowledge graph and returns the DCIDs of matches. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state). If mulitple DCIDs are returned, the first is the most likely best match given the available info.
+Given the description of an entity, this endpoint searches for an entry in the Data Commons knowledge graph and returns the DCIDs of matches. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state). If multiple DCIDs are returned, the first is the most likely best match given the available info.
 
 <div markdown="span" class="alert alert-info" role="alert">
    <span class="material-icons md-16">info </span><b>Note:</b><br />

--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -12,7 +12,17 @@ permalink: /api/rest/v1/bulk/find/entities
 
 Find the [DCID](/glossary.html#dcid) of an entity.
 
-Given the name of the entity, this endpoint searches for an entry in the Data Common knowledge graph and returns the DCID of the best match. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state).
+Given the name of the entity, this endpoint searches for an entry in the Data Commons knowledge graph and returns the DCID of the best match. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state).
+
+<div markdown="span" class="alert alert-danger" role="alert">
+   <span class="material-icons exclamation-icon">priority_high</span><b>IMPORTANT:</b><br />
+   This endpoint relies on name-based geocoding and is prone to inaccuracies. One common pattern is ambiguous place names that exist in different countries, states, etc. For example, there is at least one popular city called "Cambridge" in both the UK and USA. Thus, for more precise results, please provide as much context in the description as possible. For example, to resolve Cambridge in USA, pass "Cambridge, MA, USA" if you can.
+</div>
+
+<div markdown="span" class="alert alert-info" role="alert">
+   <span class="material-icons md-16">info </span><b>Note:</b><br />
+   Currently, this endpoint only supports [place](/glossary.html#place) entities.
+</div>
 
 ## Request
 

--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -10,7 +10,7 @@ permalink: /api/rest/v1/bulk/find/entities
 
 # /v1/bulk/find/entities
 
-Find the DCID of an entity.
+Find the [DCID](/glossary.html#dcid) of an entity.
 
 Given the name of the entity, this endpoint searches for an entry in the Data Common knowledge graph and returns the DCID of the best match. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state).
 

--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -10,18 +10,18 @@ permalink: /api/rest/v1/bulk/find/entities
 
 # /v1/bulk/find/entities
 
-Find the [DCID](/glossary.html#dcid) of an entity.
+Find the [DCIDs](/glossary.html#dcid) of multiple entities.
 
-Given the name of the entity, this endpoint searches for an entry in the Data Commons knowledge graph and returns the DCID of the best match. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state).
+Given the description of an entity, this endpoint searches for an entry in the Data Commons knowledge graph and returns the DCIDs of matches. For example, you could query for "San Francisco, CA" or "San Francisco" to find that its DCID is `geoId/0667000`. You can also provide the type of entity (country, city, state, etc.) to disambiguate (Georgia the country vs. Georgia the US state). If mulitple DCIDs are returned, the first is the most likely best match given the available info.
+
+<div markdown="span" class="alert alert-info" role="alert">
+   <span class="material-icons md-16">info </span><b>Note:</b><br />
+   Currently, this endpoint only supports [place](/glossary.html#place) entities. Support for other entity types will be added as the knowledge graph grows.
+</div>
 
 <div markdown="span" class="alert alert-danger" role="alert">
    <span class="material-icons exclamation-icon">priority_high</span><b>IMPORTANT:</b><br />
    This endpoint relies on name-based geocoding and is prone to inaccuracies. One common pattern is ambiguous place names that exist in different countries, states, etc. For example, there is at least one popular city called "Cambridge" in both the UK and USA. Thus, for more precise results, please provide as much context in the description as possible. For example, to resolve Cambridge in USA, pass "Cambridge, MA, USA" if you can.
-</div>
-
-<div markdown="span" class="alert alert-info" role="alert">
-   <span class="material-icons md-16">info </span><b>Note:</b><br />
-   Currently, this endpoint only supports [place](/glossary.html#place) entities.
 </div>
 
 ## Request
@@ -45,7 +45,7 @@ JSON Data:
     },
     {
         "description": "{entity_name_2}",
-        "type": "{entity_type_3}"
+        "type": "{entity_type_2}"
     },
     ...
   ]
@@ -63,7 +63,7 @@ There are no path parameters for this end point.
 | -------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | key <br /> <required-tag>Required</required-tag>         | string | Your API key. See the [page on authentication](/api/rest/v1/getting_started#authentication) for a demo key, as well as instructions on how to get your own key. |
 | description <br /> <required-tag>Required</required-tag> | string | The name of the entity.                                                                                                                                         |
-| type <br /> <optional-tag>Optional</optional-tag>        | string | The DCID of the entity's class. Common values are "Country", "State", "County", "City".                                                                         |
+| type <br /> <optional-tag>Optional</optional-tag>        | string | The type of entity, specified as a DCID. Common values are "Country", "State", "County", "City".                                                                         |
 {: .doc-table }
 
 ## Response
@@ -74,10 +74,16 @@ The response looks like:
 {
   "entities": [
     {
-      "description":"Description provided",
-      "type":"Type provided",
-      "dcids":["DCID"]
-    }
+      "description":"Description provided 1",
+      "type":"Type provided 1",
+      "dcids":["DCID 1"]
+    },
+    {
+      "description":"Description provided 2",
+      "type":"Type provided 2",
+      "dcids":["DCID 2"]
+    },
+    ...
   ]
 }
 ```
@@ -88,15 +94,15 @@ The response looks like:
 | Name        | Type   | Description                                                                                            |
 | ----------- | ------ | ------------------------------------------------------------------------------------------------------ |
 | description | string | The description you provided.                                                                          |
-| type        | string | The DCID of the entity's class, if provided.                                                           |
+| type        | string | The type of entity, if provided.                                                           |
 | dcids       | list   | DCIDs matching the description you provided. If no matches are found, this field will not be returned. |
 {: .doc-table}
 
 ## Examples
 
-### Example 1: Find the DCID of a place
+### Example 1: Find the DCID of places, with and without the type field
 
-Find the DCID of "Georgia". Note that the DCID of the US state of Georgia is returned.
+This queries for the DCID of "_Georgia_" twice: once without specifying type, and once with. Notice that specifying "_Georgia_" without specifying `type` returned the DCID of the US state of Georgia. When including `"type":"Country"`, the DCID of the country of Georgia is returned.
 
 Request:
 {: .example-box-title}
@@ -105,7 +111,7 @@ Request:
 curl -X POST \
 --url 'https://api.datacommons.org/v1/bulk/find/entities' \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities": [{"description": "Georgia"}]}'
+--data '{"entities": [{"description": "Georgia"}, {"description": "Georgia", "type":"Country"}]}'
 ```
 {: .example-box-content .scroll}
 
@@ -114,20 +120,25 @@ Response:
 
 ```json
 {
-  "entities": [
+  "entities":[
     {
-      "description": "Georgia",
-      "type": "Country",
-      "dcids": ["geoId/13"]
+      "description":"Georgia",
+      "dcids":["geoId/13"]
+    },
+    {
+      "description":"Georgia",
+      "type":"Country",
+      "dcids":["country/GEO"]
     }
   ]
 }
+
 ```
 {: .example-box-content .scroll}
 
-### Example 2: Find the DCID of a place that is a country
+### Example 2: Find the DCID of places, using different descriptions
 
-Find the DCID of the country of Georgia. Here we specify "Country" for type to get the DCID of the country instead of the US state.
+This queries for the DCIDs of "_Cambridge_", "_Cambridge, MA_" and "_Cambridge, UK_". Notice how including "_MA_" or "_UK_" in the description helps disambiguate.
 
 Request:
 {: .example-box-title}
@@ -136,7 +147,7 @@ Request:
 curl -X POST \
 --url 'https://api.datacommons.org/v1/bulk/find/entities' \
 --header 'X-API-Key: AIzaSyCTI4Xz-UW_G2Q2RfknhcfdAnTHq5X5XuI' \
---data '{"entities": [{"description": "Georgia", "type": "Country"}]}'
+--data '{"entities":[{"description": "Cambridge"},{"description": "Cambridge, MA"},{"description": "Cambridge, UK"}]}'
 ```
 {: .example-box-content .scroll}
 
@@ -145,11 +156,18 @@ Response:
 
 ```json
 {
-  "entities": [
+  "entities":[
     {
-      "description": "Georgia",
-      "type": "Country",
-      "dcids": ["country/GEO"]
+      "description":"Cambridge",
+      "dcids":["wikidataId/Q350"]
+    },
+    {
+      "description":"Cambridge, MA",
+      "dcids":["geoId/2511000"]
+    },
+    {
+      "description":"Cambridge, UK",
+      "dcids":["wikidataId/Q350"]
     }
   ]
 }

--- a/api/rest/v1/index.md
+++ b/api/rest/v1/index.md
@@ -61,6 +61,7 @@ Methods for retrieving information of certain types of nodes.
 | Variable Info                                 | [/v1/info/variable](/api/rest/v1/info/variable)                       | Get information about a variable               |
 | Variable Group Info                           | [/v1/info/variable-group](/api/rest/v1/info/variable-group)           | Get information about a variable group         |
 |                                               |                                                                       |                                                |
+| Find DCIDs <bulk-tag>bulk</bulk-tag>          | [/v1/bulk/find/entities](/api/rest/v1/bulk/find/entities)             | Find the DCID of an entity                     |
 | Place Info <bulk-tag>bulk</bulk-tag>          | [/v1/bulk/info/place](/api/rest/v1/bulk/info/place)                   | Get information about multiple places          |
 | Variable Info <bulk-tag>bulk</bulk-tag>       | [/v1/bulk/info/variable](/api/rest/v1/bulk/info/variable)             | Get information about multiple variables       |
 | Variable Group Info <bulk-tag>bulk</bulk-tag> | [/v1/bulk/info/variable-group](/api/rest/v1/bulk/info/variable-group) | Get information about multiple variable groups |
@@ -93,6 +94,6 @@ Methods for retrieving statistical variable related data.
 
 Methods for querying the Data Commons knowledge graph with [SPARQL](https://www.w3.org/TR/rdf-sparql-query/).
 
-| API              | URI                                               | Description                                         |
-| ---------------- | ------------------------------------------------- | --------------------------------------------------- |
-| SPARQL           | [/v1/query](/api/rest/v1/query)                   | Use SPARQL queries                                  |
+| API    | URI                             | Description        |
+| ------ | ------------------------------- | ------------------ |
+| SPARQL | [/v1/query](/api/rest/v1/query) | Use SPARQL queries |


### PR DESCRIPTION
This PR:
* Adds a documentation page for the new /v1/bulk/find/entities API
* Adds a link to the page from the REST homepage

Screenshots below:
![Screen Shot 2022-11-10 at 3 04 58 PM](https://user-images.githubusercontent.com/4034366/201224696-cf24203c-fafe-4203-aeda-44f10c95c4e7.png)

![Screen Shot 2022-11-10 at 3 05 17 PM](https://user-images.githubusercontent.com/4034366/201224702-5c692b14-bb57-4f24-83ca-0f29d2c35dbc.png)

![Screen Shot 2022-11-10 at 3 05 34 PM](https://user-images.githubusercontent.com/4034366/201224711-2d9b411f-4acc-4ed0-9fb9-4c971b692f42.png)