### PR TITLE
Add links to bulk REST API pages to the sidebar

### DIFF
--- a/api/rest/v1/_rest_bulk_api_template.md
+++ b/api/rest/v1/_rest_bulk_api_template.md
@@ -3,6 +3,7 @@ layout: default
 title: Rest API Bulk Page Template
 parent: REST (v1)
 grand_parent: API
+nav_order: 999
 published: false
 permalink: /api/rest/v1/bulk/end/point
 ---

--- a/api/rest/v1/bulk_info_place.md
+++ b/api/rest/v1/bulk_info_place.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Place Info
-nav_order: 109
+nav_order: 110
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_info_place.md
+++ b/api/rest/v1/bulk_info_place.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Place Info
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag> Place Info
+nav_order: 109
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Variable Info
-nav_order: 110
+nav_order: 111
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Variable Info
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag> Variable Info
+nav_order: 110
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_info_variable_group.md
+++ b/api/rest/v1/bulk_info_variable_group.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Variable Group Info
-nav_order: 111
+nav_order: 112
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_info_variable_group.md
+++ b/api/rest/v1/bulk_info_variable_group.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Variable Group Info
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag> Variable Group Info
+nav_order: 111
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Single Observation
-nav_order: 105.5
+nav_order: 106
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Single Observation
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag> Single Observation
+nav_order: 105.5
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_point_linked.md
+++ b/api/rest/v1/bulk_observations_point_linked.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Single Observation (linked)
-nav_order: 106
+nav_order: 107
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_point_linked.md
+++ b/api/rest/v1/bulk_observations_point_linked.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Single Observation (linked)
-nav_order: 6
+title: <bulk-tag>BULK</bulk-tag> Single Observation (linked)
+nav_order: 106
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Series of Observations
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag> Series of Observations
+nav_order: 107
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Series of Observations
-nav_order: 107
+nav_order: 108
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_series_linked.md
+++ b/api/rest/v1/bulk_observations_series_linked.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: <bulk-tag>BULK</bulk-tag> Series of Observations (linked)
-nav_order: 108
+nav_order: 109
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_observations_series_linked.md
+++ b/api/rest/v1/bulk_observations_series_linked.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Series of Observations (linked)
-nav_order: 8
+title: <bulk-tag>BULK</bulk-tag> Series of Observations (linked)
+nav_order: 108
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Properties
+title: <bulk-tag>BULK</bulk-tag>  Properties
 parent: REST (v1)
 grand_parent: API
-nav_exclude: true
+nav_order: 103
 published: true
 permalink: /api/rest/v1/bulk/properties
 ---

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag>  Properties
+title: <bulk-tag>BULK</bulk-tag> Properties
 parent: REST (v1)
 grand_parent: API
 nav_order: 103

--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Property Values
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag> Property Values
+nav_order: 104
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_property_values_linked.md
+++ b/api/rest/v1/bulk_property_values_linked.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Property Values (linked)
-nav_exclude: true
+title: <bulk-tag>BULK</bulk-tag>  Property Values (linked)
+nav_order: 105
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/bulk_property_values_linked.md
+++ b/api/rest/v1/bulk_property_values_linked.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag>  Property Values (linked)
+title: <bulk-tag>BULK</bulk-tag> Property Values (linked)
 nav_order: 105
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Triples
+title: <bulk-tag>BULK</bulk-tag> Triples
 parent: REST (v1)
 grand_parent: API
-nav_exclude: true
+nav_order: 102
 published: true
 permalink: /api/rest/v1/bulk/triples
 ---

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -3,7 +3,7 @@ layout: default
 title: <bulk-tag>BULK</bulk-tag> Variables
 parent: REST (v1)
 grand_parent: API
-nav_order: 112
+nav_order: 113
 published: true
 permalink: /api/rest/v1/bulk/variables
 ---

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -1,9 +1,9 @@
 ---
 layout: default
-title: Variables
+title: <bulk-tag>BULK</bulk-tag> Variables
 parent: REST (v1)
 grand_parent: API
-nav_exclude: true
+nav_order: 112
 published: true
 permalink: /api/rest/v1/bulk/variables
 ---

--- a/api/rest/v1/index.md
+++ b/api/rest/v1/index.md
@@ -46,10 +46,10 @@ Methods for exploring the graph around a set of nodes.
 | Property Values                                    | [/v1/property/values/](/api/rest/v1/property/values)                              | Get the value for a property of a specific node                                |
 | Property Values (linked)                           | [/v1/property/values/in/linked](/api/rest/v1/property/values/in/linked)           | Get all places of a specific type contained in an ancestor place               |
 |                                                    |                                                                                   |                                                                                |
-| Triples <bulk-tag>bulk</bulk-tag>                  | [/v1/bulk/triples](/api/rest/v1/bulk/triples)                                     | Get neighboring nodes and edge labels for multiple nodes                       |
-| Properties <bulk-tag>bulk</bulk-tag>               | [/v1/bulk/properties](/api/rest/v1/bulk/properties)                               | Get all properties for multiple nodes.                                         |
-| Property values <bulk-tag>bulk</bulk-tag>          | [/v1/bulk/property/values](/api/rest/v1/bulk/property/values)                     | Get property values for multiple properties and multiple nodes                 |
-| Property Values (linked) <bulk-tag>bulk</bulk-tag> | [/v1/bulk/property/values/in/linked](/api/rest/v1/bulk/property/values/in/linked) | Get all places of a specific type for mulitple ancestor places                 |
+| <bulk-tag>bulk</bulk-tag> Triples                   | [/v1/bulk/triples](/api/rest/v1/bulk/triples)                                     | Get neighboring nodes and edge labels for multiple nodes                       |
+| <bulk-tag>bulk</bulk-tag> Properties               | [/v1/bulk/properties](/api/rest/v1/bulk/properties)                               | Get all properties for multiple nodes.                                         |
+| <bulk-tag>bulk</bulk-tag> Property values          | [/v1/bulk/property/values](/api/rest/v1/bulk/property/values)                     | Get property values for multiple properties and multiple nodes                 |
+| <bulk-tag>bulk</bulk-tag> Property Values (linked) | [/v1/bulk/property/values/in/linked](/api/rest/v1/bulk/property/values/in/linked) | Get all places of a specific type for mulitple ancestor places                 |
 
 ### Node Information
 
@@ -61,9 +61,9 @@ Methods for retrieving information of certain types of nodes.
 | Variable Info                                 | [/v1/info/variable](/api/rest/v1/info/variable)                       | Get information about a variable               |
 | Variable Group Info                           | [/v1/info/variable-group](/api/rest/v1/info/variable-group)           | Get information about a variable group         |
 |                                               |                                                                       |                                                |
-| Place Info <bulk-tag>bulk</bulk-tag>          | [/v1/bulk/info/place](/api/rest/v1/bulk/info/place)                   | Get information about multiple places          |
-| Variable Info <bulk-tag>bulk</bulk-tag>       | [/v1/bulk/info/variable](/api/rest/v1/bulk/info/variable)             | Get information about multiple variables       |
-| Variable Group Info <bulk-tag>bulk</bulk-tag> | [/v1/bulk/info/variable-group](/api/rest/v1/bulk/info/variable-group) | Get information about multiple variable groups |
+| <bulk-tag>bulk</bulk-tag> Place Info           | [/v1/bulk/info/place](/api/rest/v1/bulk/info/place)                   | Get information about multiple places          |
+| <bulk-tag>bulk</bulk-tag> Variable Info        | [/v1/bulk/info/variable](/api/rest/v1/bulk/info/variable)             | Get information about multiple variables       |
+| <bulk-tag>bulk</bulk-tag> Variable Group Info | [/v1/bulk/info/variable-group](/api/rest/v1/bulk/info/variable-group) | Get information about multiple variable groups |
 
 ### Statistical Observations
 
@@ -75,10 +75,10 @@ entities.
 | Observation (single value)                                   | [/v1/observations/point](/api/rest/v1/observations/point)                           | Get a single value from a time-series variable for a specific entity  |
 | Observation (series)                                         | [/v1/observations/series](/api/rest/v1/observations/series)                         | Get all values from a variable for a specific entity                  |
 |                                                              |                                                                                     |                                                                       |
-| Observation (single value) <bulk-tag>bulk</bulk-tag>         | [/v1/bulk/observations/point](/api/rest/v1/bulk/observations/point)                 | Get a single value from variables for multiple entities               |
-| Observation (single value, linked) <bulk-tag>bulk</bulk-tag> | [/v1/bulk/observations/point/linked](/api/rest/v1/bulk/observations/point/linked)   | Get a single value from variables for all places in an ancestor place |
-| Observation (series) <bulk-tag>bulk</bulk-tag>               | [/v1/bulk/observations/series](/api/rest/v1/bulk/observations/series)               | Get all values from variables for multiple entities                   |
-| Observation (series, linked) <bulk-tag>bulk</bulk-tag>       | [/v1/bulk/observations/series/linked](/api/rest/v1/bulk/observations/series/linked) | Get all values from a variable for all places in an ancestor place    |
+| <bulk-tag>bulk</bulk-tag> Observation (single value)         | [/v1/bulk/observations/point](/api/rest/v1/bulk/observations/point)                 | Get a single value from variables for multiple entities               |
+| <bulk-tag>bulk</bulk-tag> Observation (single value, linked) | [/v1/bulk/observations/point/linked](/api/rest/v1/bulk/observations/point/linked)   | Get a single value from variables for all places in an ancestor place |
+| <bulk-tag>bulk</bulk-tag> Observation (series)              | [/v1/bulk/observations/series](/api/rest/v1/bulk/observations/series)               | Get all values from variables for multiple entities                   |
+| <bulk-tag>bulk</bulk-tag> Observation (series, linked)       | [/v1/bulk/observations/series/linked](/api/rest/v1/bulk/observations/series/linked) | Get all values from a variable for all places in an ancestor place    |
 
 ### Statistical Variable
 
@@ -87,7 +87,7 @@ Methods for retrieving statistical variable related data.
 | API                                 | URI                                               | Description                                         |
 | ----------------------------------- | ------------------------------------------------- | --------------------------------------------------- |
 | Variables                           | [/v1/variables](/api/rest/v1/variables)           | Get all variables associated with a specific entity |
-| Variables <bulk-tag>bulk</bulk-tag> | [/v1/bulk/variables](/api/rest/v1/bulk/variables) | Get all variables available for multiple entities   |
+| <bulk-tag>bulk</bulk-tag> Variables | [/v1/bulk/variables](/api/rest/v1/bulk/variables) | Get all variables available for multiple entities   |
 
 ### Graph Query
 

--- a/api/rest/v1/info_place.md
+++ b/api/rest/v1/info_place.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Place Info
-nav_order: 9
+nav_order: 10
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/info_variable.md
+++ b/api/rest/v1/info_variable.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Variable Info
-nav_order: 10
+nav_order: 11
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/info_variable_group.md
+++ b/api/rest/v1/info_variable_group.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Variable Group Info
-nav_order: 11
+nav_order: 12
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/observations_point.md
+++ b/api/rest/v1/observations_point.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Single Observation
-nav_order: 5
+nav_order: 6
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/observations_series.md
+++ b/api/rest/v1/observations_series.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Series of Observations
-nav_order: 7
+nav_order: 8
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/properties.md
+++ b/api/rest/v1/properties.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Properties
-nav_order: 2
+nav_order: 3
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/property_values.md
+++ b/api/rest/v1/property_values.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Property Values
-nav_order: 3
+nav_order: 4
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/property_values_linked.md
+++ b/api/rest/v1/property_values_linked.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Property Values (linked)
-nav_order: 4
+nav_order: 5
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/query.md
+++ b/api/rest/v1/query.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: SPARQL
-nav_order: 12
+nav_order: 99
 parent: REST (v1)
 grand_parent: API
 published: true

--- a/api/rest/v1/triples.md
+++ b/api/rest/v1/triples.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Triples
-nav_order: 1
+nav_order: 2
 parent: REST (v1)
 grand_parent: API
 published: true


### PR DESCRIPTION
This PR:
* Adds links to the bulk REST API pages to the sidebar, with a "bulk" tag.
* Fixes issue #251

Currently, links to the bulk pages are hidden in the simple ones and listed in the index. This change should make bulk API documentation easier for users to find.

Screenshot of new sidebar:
![Screen Shot 2022-11-14 at 9 43 48 AM](https://user-images.githubusercontent.com/4034366/201730137-3e4f90c1-42b4-414a-a99e-f53664cd1511.png)
