### PR TITLE
Fix bulk-tags showing up in page titles

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -40,7 +40,10 @@
                     {%- for grand_child in grand_children_list -%}
                       {%- unless grand_child.nav_exclude -%}
                         <li class="{% if page.url == grand_child.url %}active{% endif %}">
-                          <a href="{{ grand_child.url }}" class="{% if page.title == grand_child.title %} active{% endif %}">{{ grand_child.title }}</a>
+                          <a href="{{ grand_child.url }}" class="{% if page.title == grand_child.title %} active{% endif %}">
+                            {% if grand_child.is_bulk %}<bulk-tag>BULK</bulk-tag> {% endif %}
+                            {{ grand_child.title }}
+                          </a>
                         </li>
                       {%- endunless -%}
                     {%- endfor -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -115,7 +115,7 @@
                         </a>
                       </li>
                     {% endif %}
-                    <li class="breadcrumb-item active"><span>{{ page.title }}</span></li>
+                    <li class="breadcrumb-item active"><span>{{ page.title }} {% if page.is_bulk %}(Bulk version){% endif %}</span></li>
                   </ol>
                 </nav>
               {% endif %}

--- a/api/rest/v1/bulk_find_entities.md
+++ b/api/rest/v1/bulk_find_entities.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>bulk</bulk-tag> Find DCIDs
+title: Find DCIDs
 parent: REST (v1)
 grand_parent: API
 nav_order: 101
 published: true
 permalink: /api/rest/v1/bulk/find/entities
+is_bulk: true
 ---
 
 # /v1/bulk/find/entities

--- a/api/rest/v1/bulk_info_place.md
+++ b/api/rest/v1/bulk_info_place.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Place Info
+title: Place Info
 nav_order: 110
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/info/place
+is_bulk: true
 ---
 
 

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Variable Info
+title:  Variable Info
 nav_order: 111
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/info/variable
+is_bulk: true
 ---
 
 # /v1/bulk/info/variable

--- a/api/rest/v1/bulk_info_variable.md
+++ b/api/rest/v1/bulk_info_variable.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Variable Info
+title: Variable Info
 nav_order: 111
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_info_variable_group.md
+++ b/api/rest/v1/bulk_info_variable_group.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Variable Group Info
+title:  Variable Group Info
 nav_order: 112
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/info/variable-group
+is_bulk: true
 ---
 
 # /v1/bulk/info/variable-group

--- a/api/rest/v1/bulk_info_variable_group.md
+++ b/api/rest/v1/bulk_info_variable_group.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Variable Group Info
+title: Variable Group Info
 nav_order: 112
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Single Observation
+title:  Single Observation
 nav_order: 106
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/observations/point
- 
+is_bulk: true 
 ---
  
  

--- a/api/rest/v1/bulk_observations_point.md
+++ b/api/rest/v1/bulk_observations_point.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Single Observation
+title: Single Observation
 nav_order: 106
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_observations_point_linked.md
+++ b/api/rest/v1/bulk_observations_point_linked.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Single Observation (linked)
+title:  Single Observation (linked)
 nav_order: 107
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/observations/point/linked
+is_bulk: true
 ---
 
 # /v1/bulk/observations/point/linked

--- a/api/rest/v1/bulk_observations_point_linked.md
+++ b/api/rest/v1/bulk_observations_point_linked.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Single Observation (linked)
+title: Single Observation (linked)
 nav_order: 107
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Series of Observations
+title:  Series of Observations
 nav_order: 108
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/observations/series
- 
+is_bulk: true 
 ---
  
 # /v1/bulk/observations/series

--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Series of Observations
+title: Series of Observations
 nav_order: 108
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_observations_series_linked.md
+++ b/api/rest/v1/bulk_observations_series_linked.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Series of Observations (linked)
+title:  Series of Observations (linked)
 nav_order: 109
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/observations/series/linked
+is_bulk: true
 ---
 
 # /v1/bulk/observations/series/linked

--- a/api/rest/v1/bulk_observations_series_linked.md
+++ b/api/rest/v1/bulk_observations_series_linked.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Series of Observations (linked)
+title: Series of Observations (linked)
 nav_order: 109
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Properties
+title: Properties
 parent: REST (v1)
 grand_parent: API
 nav_order: 103

--- a/api/rest/v1/bulk_properties.md
+++ b/api/rest/v1/bulk_properties.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Properties
+title:  Properties
 parent: REST (v1)
 grand_parent: API
 nav_order: 103
 published: true
 permalink: /api/rest/v1/bulk/properties
+is_bulk: true
 ---
 
 # /v1/bulk/properties

--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Property Values
+title: Property Values
 nav_order: 104
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_property_values.md
+++ b/api/rest/v1/bulk_property_values.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Property Values
+title:  Property Values
 nav_order: 104
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/property/values
+is_bulk: true
 ---
 
 # /v1/bulk/property/values

--- a/api/rest/v1/bulk_property_values_linked.md
+++ b/api/rest/v1/bulk_property_values_linked.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Property Values (linked)
+title: Property Values (linked)
 nav_order: 105
 parent: REST (v1)
 grand_parent: API

--- a/api/rest/v1/bulk_property_values_linked.md
+++ b/api/rest/v1/bulk_property_values_linked.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Property Values (linked)
+title:  Property Values (linked)
 nav_order: 105
 parent: REST (v1)
 grand_parent: API
 published: true
 permalink: /api/rest/v1/bulk/property/values/in/linked
+is_bulk: true
 ---
 
 # /v1/bulk/property/values/in/linked

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Triples
+title: Triples
 parent: REST (v1)
 grand_parent: API
 nav_order: 102

--- a/api/rest/v1/bulk_triples.md
+++ b/api/rest/v1/bulk_triples.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Triples
+title:  Triples
 parent: REST (v1)
 grand_parent: API
 nav_order: 102
 published: true
 permalink: /api/rest/v1/bulk/triples
+is_bulk: true
 ---
 
 # /v1/bulk/triples

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title:  Variables
+title: Variables
 parent: REST (v1)
 grand_parent: API
 nav_order: 113

--- a/api/rest/v1/bulk_variables.md
+++ b/api/rest/v1/bulk_variables.md
@@ -1,11 +1,12 @@
 ---
 layout: default
-title: <bulk-tag>BULK</bulk-tag> Variables
+title:  Variables
 parent: REST (v1)
 grand_parent: API
 nav_order: 113
 published: true
 permalink: /api/rest/v1/bulk/variables
+is_bulk: true
 ---
 
 # /v1/bulk/variables


### PR DESCRIPTION
Fixes issue #280 

This PR:
- adds a `is_bulk` property to v1 bulk api pages
- Adds logic to the sidebar to render bulk-tags
- Adds "(Bulk version)" to breadcrumbs of bulk pages
- Removes bulk tags from page titles

<img width="507" alt="Screen Shot 2022-11-30 at 3 26 29 PM" src="https://user-images.githubusercontent.com/4034366/204931570-0bca3f12-e3f9-4df3-8f0a-719dc840ee43.png">

Notice tab heading no longer leads with html tags
