### PR TITLE
Fix double active links on sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -40,7 +40,7 @@
                     {%- for grand_child in grand_children_list -%}
                       {%- unless grand_child.nav_exclude -%}
                         <li class="{% if page.url == grand_child.url %}active{% endif %}">
-                          <a href="{{ grand_child.url }}" class="{% if page.title == grand_child.title %} active{% endif %}">
+                          <a href="{{ grand_child.url }}" class="{% if page.title == grand_child.title and page.is_bulk == grand_child.is_bulk %} active{% endif %}">
                             {% if grand_child.is_bulk %}<bulk-tag>BULK</bulk-tag> {% endif %}
                             {{ grand_child.title }}
                           </a>


### PR DESCRIPTION
Was too hasty on the merge for PR #282, which addressed issue #280  

This PR fixes the side effect of more than one link showing up as active on the sidebar.

Current sidebar behavior:
<img width="394" alt="Screen Shot 2022-11-30 at 5 22 33 PM" src="https://user-images.githubusercontent.com/4034366/204943379-1a14e3da-16fa-44a8-a95a-47eb8fa96bbe.png">

Proposed behavior:
<img width="413" alt="Screen Shot 2022-11-30 at 5 22 06 PM" src="https://user-images.githubusercontent.com/4034366/204943408-6e1497b1-53e2-4fa2-8819-eead1d3cbc42.png">

