### PR TITLE
Add a 3rd folder level to sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -57,7 +57,7 @@
                               {%- unless great_grand_child.nav_exclude -%}
                                 <li class="{% if page.url == great_grand_child.url %}active{% endif %}">
                                   <a href="{{ great_grand_child.url }}" class="{% if page.title == great_grand_child.title %} active{% endif %}">
-                                    {{ great_grand_child.title }}}
+                                    {{ great_grand_child.title }}
                                   </a>
                                 </li>
                               {%- endunless -%}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -18,7 +18,7 @@
             <a href="{{ node.url }}" class="{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
             {% if node.has_children %}{{ caret }}{% endif %}
           </summary>
-          {% if page.parent == node.title or page.grand_parent == node.title %}
+          {% if page.parent == node.title or page.grand_parent == node.title or page.great_grand_parent == node.title %}
             {% assign first_level_url = node.url %}
           {% endif %}
           {%- if node.has_children -%}
@@ -31,7 +31,7 @@
                     <a href="{{ child.url }}" class="{% if page.url == child.url or page.parent == child.title %} active{% endif %}">{{ child.title }}</a>
                     {% if child.has_children %}{{ caret }}{% endif %}
                   </summary>
-                  {% if page.url == child.url or page.parent == child.title %}
+                  {% if page.url == child.url or page.parent == child.title or page.grand_parent == child.title %}
                     {% assign second_level_url = child.url %}
                   {% endif %}
                   {%- if child.has_children -%}
@@ -47,7 +47,7 @@
                             </a>
                             {% if grand_child.has_children %}{{ caret }}{% endif %}
                           </summary>
-                          {% if page.url == grand_child.url or page.parent == grand_child.title %}
+                          {% if page.url == grand_child.url or page.parent == grand_child.title or page.grand_parent == grand_child.title %}
                             {% assign third_level_url = grand_child.url %}
                           {% endif %}
                           {%- if grand_child.has_children -%}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -39,9 +39,12 @@
                     <ul id="child-{{ forloop.index }}">
                     {%- for grand_child in grand_children_list -%}
                       {%- unless grand_child.nav_exclude -%}
-                        <details class="child" {% if page.url == grand_child.url or page.parent == grand_child.title or page.grand_parent == grand_child.title or page.grand_parent == "REST (v1)" %}open{% endif %}>
+                        <details class="child" {% if page.url == grand_child.url or page.parent == grand_child.title or page.grand_parent == grand_child.title %}open{% endif %}>
                           <summary>
-                            <a href="{{ grand_child.url }}" class="{% if page.url == grand_child.url or page.parent == grand_child.title %} active{% endif %}">{{ grand_child.title }}</a>
+                            <a href="{{ grand_child.url }}" class="{% if page.url == grand_child.url or page.parent == grand_child.title %} active{% endif %}">
+                              {% if grand_child.is_bulk %}<bulk-tag>BULK</bulk-tag> {% endif %}
+                              {{ grand_child.title }}
+                            </a>
                             {% if grand_child.has_children %}{{ caret }}{% endif %}
                           </summary>
                           {% if page.url == grand_child.url or page.parent == grand_child.title %}
@@ -53,7 +56,9 @@
                             {%- for great_grand_child in great_grand_children_list -%}
                               {%- unless great_grand_child.nav_exclude -%}
                                 <li class="{% if page.url == great_grand_child.url %}active{% endif %}">
-                                  <a href="{{ great_grand_child.url }}" class="{% if page.title == great_grand_child.title %} active{% endif %}">{{ great_grand_child.title }}</a>
+                                  <a href="{{ great_grand_child.url }}" class="{% if page.title == great_grand_child.title %} active{% endif %}">
+                                    {{ great_grand_child.title }}}
+                                  </a>
                                 </li>
                               {%- endunless -%}
                             {%- endfor -%}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -26,7 +26,7 @@
             <ul id="node-{{ forloop.index }}">
             {%- for child in children_list -%}
               {%- unless child.nav_exclude -%}
-                <details class="child" {% if page.url == child.url or page.parent == child.title %}open{% endif %}>
+                <details class="child" {% if page.url == child.url or page.parent == child.title or page.grand_parent == child.title %}open{% endif %}>
                   <summary>
                     <a href="{{ child.url }}" class="{% if page.url == child.url or page.parent == child.title %} active{% endif %}">{{ child.title }}</a>
                     {% if child.has_children %}{{ caret }}{% endif %}
@@ -39,12 +39,27 @@
                     <ul id="child-{{ forloop.index }}">
                     {%- for grand_child in grand_children_list -%}
                       {%- unless grand_child.nav_exclude -%}
-                        <li class="{% if page.url == grand_child.url %}active{% endif %}">
-                          <a href="{{ grand_child.url }}" class="{% if page.title == grand_child.title and page.is_bulk == grand_child.is_bulk %} active{% endif %}">
-                            {% if grand_child.is_bulk %}<bulk-tag>BULK</bulk-tag> {% endif %}
-                            {{ grand_child.title }}
-                          </a>
-                        </li>
+                        <details class="child" {% if page.url == grand_child.url or page.parent == grand_child.title or page.grand_parent == grand_child.title or page.grand_parent == "REST (v1)" %}open{% endif %}>
+                          <summary>
+                            <a href="{{ grand_child.url }}" class="{% if page.url == grand_child.url or page.parent == grand_child.title %} active{% endif %}">{{ grand_child.title }}</a>
+                            {% if grand_child.has_children %}{{ caret }}{% endif %}
+                          </summary>
+                          {% if page.url == grand_child.url or page.parent == grand_child.title %}
+                            {% assign third_level_url = grand_child.url %}
+                          {% endif %}
+                          {%- if grand_child.has_children -%}
+                            {%- assign great_grand_children_list = pages_list | where: "parent", grand_child.title | where: "grand_parent", child.title | where: "great_grand_parent", node.title -%}
+                            <ul id="grandchild-{{ forloop.index }}">
+                            {%- for great_grand_child in great_grand_children_list -%}
+                              {%- unless great_grand_child.nav_exclude -%}
+                                <li class="{% if page.url == great_grand_child.url %}active{% endif %}">
+                                  <a href="{{ great_grand_child.url }}" class="{% if page.title == great_grand_child.title %} active{% endif %}">{{ great_grand_child.title }}</a>
+                                </li>
+                              {%- endunless -%}
+                            {%- endfor -%}
+                            </ul>
+                          {%- endif -%}
+                        </details>
                       {%- endunless -%}
                     {%- endfor -%}
                     </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -97,7 +97,23 @@
               {% if page.parent %}
                 <nav aria-label="Breadcrumb" id="main-breadcrumb">
                   <ol class="breadcrumb">
-                    {% if page.grand_parent %}
+                    {% if page.great_grand_parent %}
+                    <li class="breadcrumb-item">
+                      <a href="{%- if page.great_grand_parent_url -%}{{ page.great_grand_parent_url }}{% else %}{{ first_level_url }}{% endif -%}">
+                        {{ page.great_grand_parent }}
+                      </a>
+                    </li>
+                    <li class="breadcrumb-item">
+                      <a href="{%- if page.grand_parent_url -%}{{ page.grand_parent_url }}{% else %}{{ second_level_url }}{% endif -%}">
+                        {{ page.grand_parent }}
+                      </a>
+                    </li>
+                    <li class="breadcrumb-item">
+                      <a href="{%- if page.parent_url -%}{{ page.parent_url }}{% else %}{{ third_level_url }}{% endif -%}">
+                        {{ page.parent }}
+                      </a>
+                    </li>
+                    {% elsif page.grand_parent %}
                       <li class="breadcrumb-item">
                         <a href="{%- if page.grand_parent_url -%}{{ page.grand_parent_url }}{% else %}{{ first_level_url }}{% endif -%}">
                           {{ page.grand_parent }}


### PR DESCRIPTION
This PR allows the sidebar to support one additional layer of folder nesting, which we need to add the new Data Literacy courseware to the website.

Now a structure like
```
Folder 1
  |__ Folder 2
    |__ Folder 3
      |_ my nested page 
    
```

Can be created using the following yaml front matter:
```
---
parent: Folder 3
grand_parent: Folder 2
great_grand_parent: Folder 1
---
```