### PR TITLE
[v1 api docs] clarify series are sorted by time.

### DIFF
--- a/api/rest/v1/bulk_observations_series.md
+++ b/api/rest/v1/bulk_observations_series.md
@@ -157,7 +157,7 @@ The response looks like:
 
 | Name     | Type   | Description                |
 | -------- | ------ | -------------------------- |
-| observationsByVariable   | list   | List of observations organized by variable. These are further organized by entity, and then by [facet](/glossary.html#facet).|
+| observationsByVariable   | list   | List of observations organized by variable. These are further organized by entity, and then by [facet](/glossary.html#facet). Observations are returned in chronological order. |
 | facets    | object   | Metadata on the [facet(s)](/glossary.html#facet) the data came from. Can include things like provenance, measurement method, and units. |
 {: .doc-table}
 

--- a/api/rest/v1/bulk_observations_series_linked.md
+++ b/api/rest/v1/bulk_observations_series_linked.md
@@ -137,7 +137,7 @@ The response looks like:
 
 | Name     | Type   | Description                |
 | -------- | ------ | -------------------------- |
-| observationsByVariable   | list   | List of observations organized by variable. These are further organized by entity, and then by [facet](/glossary.html#facet).|
+| observationsByVariable   | list   | List of observations organized by variable. These are further organized by entity, and then by [facet](/glossary.html#facet). Observations are returned in chronological order. |
 | facets    | object   | Metadata on the [facet(s)](/glossary.html#facet) the data came from. Can include things like provenance, measurement method, and units. |
 {: .doc-table}
 


### PR DESCRIPTION
Adds a clarification to bulk series pages that observations are returned in chronological order to the response fields.

This fixes issue #292 

Confirmed simple series page already mentions chronological order, so no change is needed on /v1/observations/series.

Example:
<img width="907" alt="Screenshot 2023-02-03 at 8 58 01 AM" src="https://user-images.githubusercontent.com/4034366/216662042-57305420-6ea6-431f-a478-c0489a173736.png">
