### PR TITLE
Always open all the sidebar menu

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,9 +11,9 @@
   {%- assign sorted_unordered_pages_list = unordered_pages_list | sort: "title" -%}
   {%- assign pages_list = sorted_ordered_pages_list | concat: sorted_unordered_pages_list -%}
   {%- for node in pages_list -%}
-    {%- if node.nav_exclude != true || node.open -%}
+    {%- if node.nav_exclude != true -%}
       {%- if node.parent == nil and node.title -%}
-        <details class="parent" {% if node.open %}open{% endif %}>
+        <details class="parent" open>
           <summary>
             <a href="{{ node.url }}" class="{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
             {% if node.has_children %}{{ caret }}{% endif %}

--- a/api/index.md
+++ b/api/index.md
@@ -3,7 +3,6 @@ layout: default
 title: API
 nav_order: 20
 has_children: true
-open: true
 ---
 # Overview
 

--- a/courseware/index.md
+++ b/courseware/index.md
@@ -3,7 +3,6 @@ layout: default
 title: Courseware
 nav_order: 60
 has_children: true
-open: true
 ---
 
 # Courseware


### PR DESCRIPTION
This is to revert an early change to collapse some of the menu on page loading.

This does not work well when opening a top level item, and click on its child. Then the page reload with the top level item closed again.

We strongly need a simple state management of the site. Given all the complexity of Jekyll, we should consider using React to re-write this site.