### PR TITLE
Publish Web Component Documentation

### DIFF
--- a/api/web_components/bar.md
+++ b/api/web_components/bar.md
@@ -4,7 +4,7 @@ title: Bar Chart
 nav_order: 1
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/bar
 ---
 

--- a/api/web_components/gauge.md
+++ b/api/web_components/gauge.md
@@ -4,7 +4,7 @@ title: Gauge Chart
 nav_order: 2
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/gauge
 ---
 

--- a/api/web_components/highlight.md
+++ b/api/web_components/highlight.md
@@ -4,7 +4,7 @@ title: Highlight Tile
 nav_order: 3
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/highlight
 ---
 

--- a/api/web_components/index.md
+++ b/api/web_components/index.md
@@ -4,7 +4,7 @@ title: Web Components
 parent: API
 nav_order: 20
 has_children: true
-published: false
+published: true
 ---
 # Data Commons Web Components
 
@@ -16,6 +16,17 @@ visualizations in your web application.
   src="/assets/images/web_components/all.png"
   style="width: 100%; max-width: 1024px;"
 />
+
+<div markdown="span" class="alert alert-info" role="alert">
+    <span class="material-icons md-16">info </span>
+    <b>Are you using the Data Commons Web Components?</b><br />
+    Sign up for our announcement mailing list to stay up to date with our latest
+    developments. Join the list by
+    <a
+      href="https://groups.google.com/g/datacommons-announce"
+      target="_blank"
+    >clicking here</a>, then clicking the “Join group” button.
+</div>
 
 ## Usage
 

--- a/api/web_components/line.md
+++ b/api/web_components/line.md
@@ -4,7 +4,7 @@ title: Line Chart
 nav_order: 4
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/line
 ---
 

--- a/api/web_components/map.md
+++ b/api/web_components/map.md
@@ -4,7 +4,7 @@ title: Map Chart
 nav_order: 5
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/map
 ---
 

--- a/api/web_components/pie.md
+++ b/api/web_components/pie.md
@@ -4,7 +4,7 @@ title: Pie Chart
 nav_order: 6
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/pie
 ---
 

--- a/api/web_components/ranking.md
+++ b/api/web_components/ranking.md
@@ -4,7 +4,7 @@ title: Ranking Chart
 nav_order: 7
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/ranking
 ---
 

--- a/api/web_components/scatter.md
+++ b/api/web_components/scatter.md
@@ -4,7 +4,7 @@ title: Scatter Plot
 nav_order: 8
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/scatter
 ---
 

--- a/api/web_components/slider.md
+++ b/api/web_components/slider.md
@@ -4,7 +4,7 @@ title: Slider Control
 nav_order: 9
 parent: Web Components
 grand_parent: API
-published: false
+published: true
 permalink: /api/web_components/slider
 ---
 


### PR DESCRIPTION
Publish web component pages, and adds a blurb to the web component index page asking users to sign up for the datacommons-announce list for development updates.

Screenshot of index page:
![Screenshot 2023-11-06 at 3 51 38 PM](https://github.com/datacommonsorg/docsite/assets/4034366/8a593e75-558e-4224-ac3b-bf0d100b3b34)
