### PR TITLE
Applied formatting to custom dc docs

### DIFF
--- a/custom_dc/build_repo.md
+++ b/custom_dc/build_repo.md
@@ -19,7 +19,7 @@ Data Commons provides two prebuilt images in the Google Artifact Registry that y
 If you want to pick up the latest prebuilt version, run the following command:
 
 ```shell
-docker pull gcr.io/gcr.io/datcom-ci/datacommons-website-compose:latest
+docker pull gcr.io/datcom-ci/datacommons-website-compose:latest
 ```
 
 Then, restart Docker, specifying that repo as the argument to the `docker run` command.

--- a/custom_dc/build_repo.md
+++ b/custom_dc/build_repo.md
@@ -9,13 +9,13 @@ parent: Custom Data Commons
 
 Data Commons provides two prebuilt images in the Google Artifact Registry that you can download to run in a Docker container:
 
--  `gcr.io/datcom-ci/datacommons-website-compose:stable`. This is a tested, stable version but may be several weeks old.
--  `gcr.io/datcom-ci/datacommons-website-compose:latest`. This is the latest built version that is running in production.
+- `gcr.io/datcom-ci/datacommons-website-compose:stable`. This is a tested, stable version but may be several weeks old.
+- `gcr.io/datcom-ci/datacommons-website-compose:latest`. This is the latest built version that is running in production.
 
 If you want to pick up the latest prebuilt version, run the following command:
 
-```shell  
-docker pull gcr.io/gcr.io/datcom-ci/datacommons-website-compose:latest  
+```shell
+docker pull gcr.io/gcr.io/datcom-ci/datacommons-website-compose:latest
 ```
 
 Then, restart Docker, specifying that repo as the argument to the `docker run` command.
@@ -28,41 +28,41 @@ If you need to rebuild the repo locally, you must also update the `mixer` and `i
 
 1. From the `website` directory, sync to the latest version of the files in the repo:
 
-    ```shell  
-    git submodule foreach git pull origin master  
-    git submodule update --init --recursive  
-    git pull 
-    ```
+   ```shell
+   git submodule foreach git pull origin master
+   git submodule update --init --recursive
+   git pull
+   ```
+
 1. Run the following command to build the repo:
 
-    <pre>
-    docker build --tag datacommons-website-compose:<var>DOCKER_TAG</var> \
-    -f build/web_compose/Dockerfile \
-    -t website-compose .  
-    </pre>
+   <pre>
+   docker build --tag datacommons-website-compose:<var>DOCKER_TAG</var> \
+   -f build/web_compose/Dockerfile \
+   -t website-compose .
+   </pre>
 
-    The _DOCKER_TAG_ is a meaningful description of the version you are building.
+   The _DOCKER_TAG_ is a meaningful description of the version you are building.
 
-It will take several minutes to build. 
+It will take several minutes to build.
 
-To run the container with the local SQLite database, start the Docker container as described below. 
+To run the container with the local SQLite database, start the Docker container as described below.
 
 To run the container with a remote Cloud SQL database, see [Start the Docker container with Cloud data](/custom_dc/data_cloud.html#docker-data) for procedures.
 
 To upload and deploy the container to the Cloud, see [Deploy a custom instance to Google Cloud](/custom_dc/deploy_cloud.html) for procedures.
-
 
 ## Run the container with the local SQLite database
 
 To start the services using the locally built repo. If you have made changes to any of the UI components, be sure to map the `custom` directories to the Docker `workspace` directory.
 
 <pre>  
-docker run -it \  
---env-file $PWD/custom_dc/sqlite_env.list \  
--p 8080:8080 \  
--e DEBUG=true \  
-[-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>:/userdata \]  
-[-v $PWD/server/templates/custom_dc/custom:/workspace/server/templates/custom_dc/custom \]  
+docker run -it \
+--env-file $PWD/custom_dc/sqlite_env.list \
+-p 8080:8080 \
+-e DEBUG=true \
+[-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>:/userdata \]
+[-v $PWD/server/templates/custom_dc/custom:/workspace/server/templates/custom_dc/custom \]
 [-v $PWD/static/custom_dc/custom:/workspace/static/custom_dc/custom \]
-datacommons-website-compose:<var>DOCKER_TAG</var>  
+datacommons-website-compose:<var>DOCKER_TAG</var>
 </pre>

--- a/custom_dc/custom_data.md
+++ b/custom_dc/custom_data.md
@@ -7,47 +7,48 @@ parent: Custom Data Commons
 
 ## Work with custom data
 
-Custom Data Commons provides a simple mechanism to import your own data, but it requires that the data be provided in a specific format and file structure. 
+Custom Data Commons provides a simple mechanism to import your own data, but it requires that the data be provided in a specific format and file structure.
 
--  All data must be in CSV format, using the schema described below.
--  You must also provide a JSON configuration file, named `config.json`, to map the CSV contents to the Data Commons schema knowledge graph. The contents of the JSON file are described below.
--  All CSV files and the JSON file must be in the same directory
+- All data must be in CSV format, using the schema described below.
+- You must also provide a JSON configuration file, named `config.json`, to map the CSV contents to the Data Commons schema knowledge graph. The contents of the JSON file are described below.
+- All CSV files and the JSON file must be in the same directory
 
 Examples are provided in [`custom_dc/sample`](https://github.com/datacommonsorg/website/tree/master/custom_dc/sample) and [`custom_dc/examples`](https://github.com/datacommonsorg/website/tree/master/custom_dc/examples) directories.
 
 ## Prepare the CSV files {#prepare-csv}
 
-Custom Data Commons provides a simplified data model, which allows your data to be mapped to the Data Commons knowledge graph schema. Data in the CSV files should conform to a _variable per column_ scheme. This requires minimal manual configuration; the Data Commons importer can create observations and statistical variables if they don't already exist, and it resolves all columns to [DCID](/glossary.html#dcid)s. 
+Custom Data Commons provides a simplified data model, which allows your data to be mapped to the Data Commons knowledge graph schema. Data in the CSV files should conform to a _variable per column_ scheme. This requires minimal manual configuration; the Data Commons importer can create observations and statistical variables if they don't already exist, and it resolves all columns to [DCID](/glossary.html#dcid)s.
 
 With the variable-per-column scheme, data is provided in this format, in this exact sequence:
 
 _ENTITY, OBSERVATION_DATE, STATISTICAL_VARIABLE1, STATISTICAL_VARIABLE2, …_
 
-There are two properties, the _ENTITY_ and the _OBSERVATION\_DATE_, that specify the place and time of the observation; all other properties must be expressed as [statistical variables](/glossary.html#variable). To illustrate what this means, consider this example: let's say you have a dataset that provides the number of public schools in U.S. cities, broken down by elementary, middle, secondary and postsecondary. Your data might have the following structure, which we identify as _variable per row_ (numbers are not real, but are just made up for the sake of example):
+There are two properties, the _ENTITY_ and the _OBSERVATION_DATE_, that specify the place and time of the observation; all other properties must be expressed as [statistical variables](/glossary.html#variable). To illustrate what this means, consider this example: let's say you have a dataset that provides the number of public schools in U.S. cities, broken down by elementary, middle, secondary and postsecondary. Your data might have the following structure, which we identify as _variable per row_ (numbers are not real, but are just made up for the sake of example):
 
-```csv  
-city,year,typeOfSchool,count  
-San Francisco,2023,elementary,300  
-San Francisco,2023,middle,300  
-San Francisco,2023,secondary,200  
-San Francisco,2023,postsecondary,50  
-San Jose,2023,elementary,400  
-San Jose,2023,middle,400  
-San Jose,2023,secondary,300  
-San Jose,2023,postsecondary,50  
+```csv
+city,year,typeOfSchool,count
+San Francisco,2023,elementary,300
+San Francisco,2023,middle,300
+San Francisco,2023,secondary,200
+San Francisco,2023,postsecondary,50
+San Jose,2023,elementary,400
+San Jose,2023,middle,400
+San Jose,2023,secondary,300
+San Jose,2023,postsecondary,50
 ```
 
 For custom Data Commons, you need to format it so that every property corresponds to a separate statistical variable, like this:
 
-```csv  
-city,year,countElementary,countMiddle,countSecondary,countPostSecondary  
-San Francisco,2023,300,300,200,50  
-San Jose,2023,400,400,300,0  
+```csv
+city,year,countElementary,countMiddle,countSecondary,countPostSecondary
+San Francisco,2023,300,300,200,50
+San Jose,2023,400,400,300,0
 ```
+
 The _ENTITY_ is an existing property in the Data Commons knowledge graph that is used to describe an entity, most commonly a place. The best way to think of the entity type is as a key that could be used to join to other data sets. The column heading can be expressed as any existing place-related property; see [Place types](/place_types.html) for a full list. It may also be any of the special DCID prefixes listed in [Special place names](#special-names).
 The _DATE_ is the date of the observation and should be in the format _YYYY_, _YYYY_-_MM_, or _YYYY_-_MM_-_DD_. The heading can be anything, although as a best practice, we recommend using a corresponding identifier, such as `year`, `month` or `date`.
 
-The _VARIABLE_ should contain a metric [observation](/glossary.html#observation) at a particular time. We recommend that you try to reuse existing statistical variables where feasible; use the main Data Commons [Statistical Variable Explorer](https://datacommons.org/tools/statvar) to find them. If there is no existing statistical variable you can use, name the heading with an illustrative name and the importer will create a new variable for you. 
+The _VARIABLE_ should contain a metric [observation](/glossary.html#observation) at a particular time. We recommend that you try to reuse existing statistical variables where feasible; use the main Data Commons [Statistical Variable Explorer](https://datacommons.org/tools/statvar) to find them. If there is no existing statistical variable you can use, name the heading with an illustrative name and the importer will create a new variable for you.
 
 The variable values must be numeric. Zeros and null values are accepted: zeros will be recorded and null values ignored.
 
@@ -57,37 +58,39 @@ All headers must be in camelCase.
 
 In addition to the place names listed in [Place types](/place_types.html), you can also use the following special names:
 
-* [`dcid`](/glossary.html#dcid) --- An already resolved DC ID. Examples:`country/USA`, `geoId/06`
-* `country3AlphaCode` --- Three-character country codes. Examples: `USA`, `CHN`
-* `geoId` --- Place geo IDs. Examples: `06`, `023`
-* `lat#lng` --- Latitude and longitude of the place using the format _lat_#_long_. Example: `38.7#-119.4`
-* `wikidataId` --- Wikidata place identifiers. Example: `Q12345`
+- [`dcid`](/glossary.html#dcid) --- An already resolved DC ID. Examples:`country/USA`, `geoId/06`
+- `country3AlphaCode` --- Three-character country codes. Examples: `USA`, `CHN`
+- `geoId` --- Place geo IDs. Examples: `06`, `023`
+- `lat#lng` --- Latitude and longitude of the place using the format _lat_#_long_. Example: `38.7#-119.4`
+- `wikidataId` --- Wikidata place identifiers. Example: `Q12345`
 
 You can also simply use the heading `name` or `place` and the importer will resolve it automatically.
 
-The following are all valid examples of headers:  
-   
-```csv 
-geoId,observationYear,statVar1,statVar2  
-06,2021,555,666  
-08,2021,10,10  
-```  
-```csv 
-name,observationYear,statVar1,statVar2  
-California,2021,555,666  
-Colorado,2021,10,10  
-```  
-```csv 
-dcId,observationYear,statVar1,statVar2  
-geoId/06,2021,555,666  
-geoId/08,2021,10,10  
+The following are all valid examples of headers:
+
+```csv
+geoId,observationYear,statVar1,statVar2
+06,2021,555,666
+08,2021,10,10
+```
+
+```csv
+name,observationYear,statVar1,statVar2
+California,2021,555,666
+Colorado,2021,10,10
+```
+
+```csv
+dcId,observationYear,statVar1,statVar2
+geoId/06,2021,555,666
+geoId/08,2021,10,10
 ```
 
 ## Write the data config file
 
-The config.json file specifies how the CSV contents should be mapped and resolved to the Data Commons schema. See the example in the [`sample/config.json`](https://github.com/datacommonsorg/website/blob/master/custom_dc/sample/config.json) file provided, which describes the data in the [`sample/average_annual_wage.csv`](https://github.com/datacommonsorg/website/blob/master/custom_dc/sample/average_annual_wage.csv) and [`sample/gender_wage_gap.csv`](https://github.com/datacommonsorg/website/blob/master/custom_dc/sample/gender_wage_gap.csv) files.  
+The config.json file specifies how the CSV contents should be mapped and resolved to the Data Commons schema. See the example in the [`sample/config.json`](https://github.com/datacommonsorg/website/blob/master/custom_dc/sample/config.json) file provided, which describes the data in the [`sample/average_annual_wage.csv`](https://github.com/datacommonsorg/website/blob/master/custom_dc/sample/average_annual_wage.csv) and [`sample/gender_wage_gap.csv`](https://github.com/datacommonsorg/website/blob/master/custom_dc/sample/gender_wage_gap.csv) files.
 
-Here is the general spec for the JSON file:  
+Here is the general spec for the JSON file:
 
 <pre>
 {  
@@ -135,17 +138,18 @@ Each section contains some required and optional fields, which are described in 
 
 The top-level `inputFiles` field should encode a map from the input file name to parameters specific to that file. Keys can be individual file names or wildcard patterns if the same config applies to multiple files.
 
-You can use the `*` wildcard; matches are applied in the order in which they are specified in the config. For example, in the following:  
+You can use the `*` wildcard; matches are applied in the order in which they are specified in the config. For example, in the following:
 
 ```
-{  
- "inputFiles": {  
-    "foo.csv": {...},  
-    "bar*.csv": {...},  
-    "*.csv": {...}  
-  }  
-}  
-```  
+{
+ "inputFiles": {
+    "foo.csv": {...},
+    "bar*.csv": {...},
+    "*.csv": {...}
+  }
+}
+```
+
 The first set of parameters only applies to `foo.csv`. The second set of parameters applies to `bar.csv`, `bar1.csv`, `bar2.csv`, etc. The third set of parameters applies to all CSVs except the previously specified ones, namely `foo.csv` and `bar*.csv`.
 
 #### Input file parameters
@@ -160,10 +164,9 @@ The first set of parameters only applies to `foo.csv`. The second set of paramet
 
 `provenance`
 
-: Required: The provenance (name) of this input file. Provenances typically map to a dataset from a source. For example, `WorldDevelopmentIndicators` provenance (or dataset) is from the `WorldBank` source.  
+: Required: The provenance (name) of this input file. Provenances typically map to a dataset from a source. For example, `WorldDevelopmentIndicators` provenance (or dataset) is from the `WorldBank` source.
 
 You must specify the provenance details under `sources`.`provenances`; this field associates one of the provenances defined there to this file.
-
 
 ### Variables
 
@@ -180,19 +183,19 @@ The name should be concise and precise; that is, the shortest possible name that
 
 : A long-form description of the variable.
 
-`properties` 
+`properties`
 
-: Additional Data Commons properties associated with this variable. These are Data Commons property entities. See [Representing statistics in Data Commons](https://github.com/datacommonsorg/data/blob/master/docs/representing_statistics.md) for more details.  
+: Additional Data Commons properties associated with this variable. These are Data Commons property entities. See [Representing statistics in Data Commons](https://github.com/datacommonsorg/data/blob/master/docs/representing_statistics.md) for more details.
 
-Each property is specified as a key:value pair. Here are some examples:  
+Each property is specified as a key:value pair. Here are some examples:
 
 ```json
 {
-  "populationType": "schema:Person",  
-  "measuredProperty": "age",  
-  "statType": "medianValue",  
-  "gender": "Female" 
-} 
+  "populationType": "schema:Person",
+  "measuredProperty": "age",
+  "statType": "medianValue",
+  "gender": "Female"
+}
 ```
 
 `group`
@@ -205,11 +208,11 @@ You can have a multi-level group hierarchy by using `/` as a separator between e
 
 `searchDescriptions`
 
-: An array of descriptions to be used for creating more NL embeddings for the variable. This is only needed if the variable `name` is not sufficient for generating embeddings.  
+: An array of descriptions to be used for creating more NL embeddings for the variable. This is only needed if the variable `name` is not sufficient for generating embeddings.
 
 ### Sources
 
-The `sources` section is optional. It encodes the sources and provenances associated with the input dataset. Each named source is a mapping of provenances to URLs. 
+The `sources` section is optional. It encodes the sources and provenances associated with the input dataset. Each named source is a mapping of provenances to URLs.
 
 #### Source parameters
 
@@ -221,7 +224,7 @@ The `sources` section is optional. It encodes the sources and provenances associ
 
 ```json
 {
-  "USA Top Baby Names 2022": "https://www.ssa.gov/oact/babynames/"
+  "USA Top Baby Names 2022": "https://www.ssa.gov/oact/babynames/",
   "USA Top Baby Names 1923-2022": "https://www.ssa.gov/oact/babynames/decades/century.html"
 }
 ```
@@ -235,13 +238,13 @@ To load custom data uploaded to Google Cloud, see instead [Pointing the local Da
 Once you have your CSV files and config.json set up, use the following command to restart the Docker container, mapping your custom data directory to the Docker userdata directory.
 
 <pre>
-docker run -it \  
--p 8080:8080 \  
--e DEBUG=true \  
---env-file $PWD/custom_dc/sqlite_env.list \  
--v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>:/userdata \  
-[-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons:/sqlite]  
-gcr.io/datcom-ci/datacommons-website-compose:stable  
+docker run -it \
+-p 8080:8080 \
+-e DEBUG=true \
+--env-file $PWD/custom_dc/sqlite_env.list \
+-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>:/userdata \
+[-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons:/sqlite]
+gcr.io/datcom-ci/datacommons-website-compose:stable
 </pre>
 
 The optional `-v` flag preserves the SQLite data so it loads automatically when you restart the Docker container.
@@ -255,34 +258,35 @@ As you are iterating on changes to the source CSV and JSON files, you will need 
 You can load the new/updated data from SQLite using the `/admin` page on the site:
 
 1. Optionally, in the `sqlite_env.list` file, set the `ADMIN_SECRET` environment variable to a string that authorizes users to load data.
-1. Start the Docker container as usual, being sure to map the path to the directory containing the custom data (see command above). 
-1. With the services running, navigate to the `/admin page`. If a secret is required, enter it in the text field, and click **Load**. This runs a script inside the Docker container, that converts the CSV data into SQL tables, and generates embeddings in the container as well. The database is created as <code>custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons/datacommons.db</code> and embeddings are generated in <code>custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons/nl/</code>. 
+1. Start the Docker container as usual, being sure to map the path to the directory containing the custom data (see command above).
+1. With the services running, navigate to the `/admin page`. If a secret is required, enter it in the text field, and click **Load**. This runs a script inside the Docker container, that converts the CSV data into SQL tables, and generates embeddings in the container as well. The database is created as <code>custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons/datacommons.db</code> and embeddings are generated in <code>custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons/nl/</code>.
 
 ## Inspect the SQLite database
 
 If you need to troubleshoot custom data, it is helpful to inspect the contents of the generated SQLite database.
 
 To do so, from a terminal window, open the database:
+
 <pre>  
 sqlite3 website/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons/datacommons.db
 </pre>
 
-This starts the interactive SQLite shell. To view a list of tables, at the prompt type `.tables`. The relevant table is `observations`. 
+This starts the interactive SQLite shell. To view a list of tables, at the prompt type `.tables`. The relevant table is `observations`.
 
 At the prompt, enter SQL queries. For example, for the sample OECD data, this query:
 
-```shell  
-sqlite> select * from observations limit 10;  
+```shell
+sqlite> select * from observations limit 10;
 ```
 
 returns output like this:
 
-```shell  
-country/BEL|average_annual_wage|2000|54577.62735|c/p/1  
-country/BEL|average_annual_wage|2001|54743.96009|c/p/1  
-country/BEL|average_annual_wage|2002|56157.24355|c/p/1  
-country/BEL|average_annual_wage|2003|56491.99591|c/p/1  
-country/BEL|average_annual_wage|2004|56195.68432|c/p/1  
-country/BEL|average_annual_wage|2005|55662.21541|c/p/1  
-...  
+```shell
+country/BEL|average_annual_wage|2000|54577.62735|c/p/1
+country/BEL|average_annual_wage|2001|54743.96009|c/p/1
+country/BEL|average_annual_wage|2002|56157.24355|c/p/1
+country/BEL|average_annual_wage|2003|56491.99591|c/p/1
+country/BEL|average_annual_wage|2004|56195.68432|c/p/1
+country/BEL|average_annual_wage|2005|55662.21541|c/p/1
+...
 ```

--- a/custom_dc/custom_ui.md
+++ b/custom_dc/custom_ui.md
@@ -2,15 +2,15 @@
 layout: default
 title: Customize the site
 nav_order: 4
-parent:  Custom Data Commons
+parent: Custom Data Commons
 ---
 
 ## Customize the site
 
 The default custom Data Commons image provides a bare-bones UI that you will undoubtedly want to customize to your liking. Data Commons uses the Python [Flask](https://flask.palletsprojects.com/en/3.0.x/#) web framework and [Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/) HTML templates. If you're not familiar with these, the following documents are good starting points:
 
--  [Flask Templates](https://flask.palletsprojects.com/en/3.0.x/tutorial/templates/) 
--  [Flask Static Files](https://flask.palletsprojects.com/en/3.0.x/tutorial/static/)
+- [Flask Templates](https://flask.palletsprojects.com/en/3.0.x/tutorial/templates/)
+- [Flask Static Files](https://flask.palletsprojects.com/en/3.0.x/tutorial/static/)
 
 HTML and CSS customization files are provided as samples to get you started. They are as follows:
 
@@ -45,18 +45,18 @@ HTML and CSS customization files are provided as samples to get you started. The
   </tbody>
 </table>
 
-Note that the `custom` parent directory is customizable as the `FLASK_ENV` environment variable. You can rename the directory as desired and update the environment variable.  
+Note that the `custom` parent directory is customizable as the `FLASK_ENV` environment variable. You can rename the directory as desired and update the environment variable.
 
-To enable the changes to be picked up by the Docker image, and allow you to refresh the browser for further changes, restart the Docker image with this additional flag to map the directories to the Docker workspace:  
+To enable the changes to be picked up by the Docker image, and allow you to refresh the browser for further changes, restart the Docker image with this additional flag to map the directories to the Docker workspace:
 
-```shell  
--v $PWD/server/templates/custom_dc/custom:/workspace/server/templates/custom_dc/custom  
--v $PWD/static/custom_dc/custom:/workspace/static/custom_dc/custom  
+```shell
+-v $PWD/server/templates/custom_dc/custom:/workspace/server/templates/custom_dc/custom
+-v $PWD/static/custom_dc/custom:/workspace/static/custom_dc/custom
 ```
+
 <!--[Note: the second line doesn't currently do anything, but this is the way it should work IMO]-->
 
 If you have renamed the parent `custom` directory, be sure to use that name in the flag.
-
 
 ## Customize HTML templates {#html-templates}
 
@@ -66,7 +66,7 @@ You can customize the page header and footer (by default, empty) in [base.html](
 
 ## Customize Javascript and styles {#styles}
 
-Use the [overrides.css](https://github.com/datacommonsorg/website/blob/master/static/custom_dc/custom/overrides.css) file to customize the default Data Commons styles. The file provides a default color override. You can add all style overrides to that file.   
+Use the [overrides.css](https://github.com/datacommonsorg/website/blob/master/static/custom_dc/custom/overrides.css) file to customize the default Data Commons styles. The file provides a default color override. You can add all style overrides to that file.
 
 Alternatively, if you have existing existing CSS and Javascript files, put them under the [/static/custom_dc/custom](https://github.com/datacommonsorg/website/blob/master/static/custom_dc/custom) folder. Then include these files in the `<head>` section of the corresponding HTML files as:
 
@@ -74,6 +74,6 @@ Alternatively, if you have existing existing CSS and Javascript files, put them 
 &lt;link href="/custom_dc/custom/<var>FILENAME</var>.css|js" rel="stylesheet" /&gt;
 </pre>
 
-See [`server/templates/custom_dc/custom/new.html`](https://github.com/datacommonsorg/website/blob/master/server/templates/custom_dc/custom/new.html) as an example.  
+See [`server/templates/custom_dc/custom/new.html`](https://github.com/datacommonsorg/website/blob/master/server/templates/custom_dc/custom/new.html) as an example.
 
-Note: Currently, making changes to any of the files in the `static/` directory requires that you rebuild a local version of the repo to pick up the changes, as described in [Build and run a local repo](/custom_dc/build_repo.html). We plan to fix this in the near future. 
+Note: Currently, making changes to any of the files in the `static/` directory requires that you rebuild a local version of the repo to pick up the changes, as described in [Build and run a local repo](/custom_dc/build_repo.html). We plan to fix this in the near future.

--- a/custom_dc/data_cloud.md
+++ b/custom_dc/data_cloud.md
@@ -2,7 +2,7 @@
 layout: default
 title: Test data in Google Cloud
 nav_order: 6
-parent:  Custom Data Commons
+parent: Custom Data Commons
 ---
 
 ## Test data in Google Cloud
@@ -11,19 +11,18 @@ Once you have tested locally, you need to get your data into Google Cloud so you
 
 ![setup3](/assets/images/custom_dc/customdc_setup3.png)
 
-You will upload your CSV and JSON files to [Google Cloud Storage](https://cloud.google.com/storage), and the custom Data Commons importer will transform, store, and query the data in a [Google Cloud SQL](https://cloud.google.com/sql) database. 
+You will upload your CSV and JSON files to [Google Cloud Storage](https://cloud.google.com/storage), and the custom Data Commons importer will transform, store, and query the data in a [Google Cloud SQL](https://cloud.google.com/sql) database.
 
 ## Prerequisites
 
--  A [GCP](https://console.cloud.google.com/welcome) billing account and project.
--  Install the [gcloud CLI](https://cloud.google.com/sdk/docs/install-sdk).
+- A [GCP](https://console.cloud.google.com/welcome) billing account and project.
+- Install the [gcloud CLI](https://cloud.google.com/sdk/docs/install-sdk).
 
 ## One-time setup steps
 
 ### Choose a location
 
 While you are testing, you can start with a single Google Cloud region; to be close to the main Data Commons data, you can use `us-central1`. However, once you launch, you may want to host your data and application closer to where your users will be. In any case, you should use the _same region_ for your Google Cloud SQL instance, the Google Cloud Storage buckets, and the [Google Cloud Run service](deploy_cloud.md) where you will host the site. For a list of supported regions, see Cloud SQL [Manage instance locations](https://cloud.google.com/sql/docs/mysql/locations).
-
 
 ### Create a Google Cloud SQL instance
 
@@ -33,38 +32,39 @@ While you are testing, you can start with a single Google Cloud region; to be cl
 1. If necessary, enable APIs as directed.
 1. Set an instance ID. Record the instance connection name in the form of _`INSTANCE_ID`_ for setting environment variables below.
 1. Set a root password, and record it for setting environment variables below.
-1. For the **Location type**, choose the relevant regional option. 
+1. For the **Location type**, choose the relevant regional option.
 1. When you have finished setting all the configuration options, click **Create Instance**. It may take several minutes for the instance to be created.
 1. When the instance is created and the left navigation bar appears, select **Users**.
 1. Add at least one user and password.
 1. Select **Databases**.
-1.  Click **Create Database**.
-1. Choose a name for the database or use the default, `datacommons`. 
+1. Click **Create Database**.
+1. Choose a name for the database or use the default, `datacommons`.
 1. Click **Create**.
 
 ### Create a Google Cloud Storage bucket
 
-1. Go to [https://console.cloud.google.com/storage/browser](https://console.cloud.google.com/storage/browser) for your project. 
+1. Go to [https://console.cloud.google.com/storage/browser](https://console.cloud.google.com/storage/browser) for your project.
 1. Next to **Buckets**, click **Create**.
 1. Enter a name for this bucket.
 1. For the **Location type**, choose the same regional options as for Cloud SQL above.
 1. When you have finished setting all the configuration options, click **Create**.
-1. In the **Bucket Details** page, click **Create Folder** to create a new folder to hold your data. 
+1. In the **Bucket Details** page, click **Create Folder** to create a new folder to hold your data.
 1. Name the folder as desired. Record the folder path as <code>gs://<var>BUCKET_NAME</var>/<var>FOLDER_PATH</var></code> for setting environment variables below. You can start with the sample data provided under `custom_dc/sample` and update to your own data later.
 
 ### Set up environment variables
 
 1. Using your favorite editor, open `custom_dc/cloudsql_env.list`.
-1. Enter the relevant values for `DC_API_KEY` and `MAPS_API_KEY`. 
+1. Enter the relevant values for `DC_API_KEY` and `MAPS_API_KEY`.
 1. Set values for all of the following:
-    -  `GCS_DATA_PATH`
-    -  `CLOUDSQL_INSTANCE`
-    -  `GOOGLE_CLOUD_PROJECT`
-    -  `DB_NAME`
-    -  `DB_USER`
-    -  `DB_PASS`
 
-    See comments in the [`cloudsql_env.list`](https://github.com/datacommonsorg/website/blob/master/custom_dc/cloudsql_env.list) file for the correct format for each option.
+   - `GCS_DATA_PATH`
+   - `CLOUDSQL_INSTANCE`
+   - `GOOGLE_CLOUD_PROJECT`
+   - `DB_NAME`
+   - `DB_USER`
+   - `DB_PASS`
+
+   See comments in the [`cloudsql_env.list`](https://github.com/datacommonsorg/website/blob/master/custom_dc/cloudsql_env.list) file for the correct format for each option.
 
 1. Optionally, set an `ADMIN_SECRET` to use when loading the data through the `/admin` page later.
 
@@ -74,7 +74,7 @@ Warning: Do not use any quotes (single or double) or spaces when specifying the 
 
 1. Go to [https://console.cloud.google.com/storage/browse](https://console.cloud.google.com/storage/browse) and select your custom Data Commons bucket.
 1. Navigate to the folder you created in the earlier step.
-1. Click **Upload Files**, and select all your CSV files and `config.json`. 
+1. Click **Upload Files**, and select all your CSV files and `config.json`.
 
 Note: Do not upload the local `datacommons` subdirectory or its files.
 
@@ -88,8 +88,8 @@ Before you can connect to the Cloud SQL instance, you need to generate credentia
 
 Open a terminal window and run the following command:
 
-```shell  
-gcloud auth application-default login  
+```shell
+gcloud auth application-default login
 ```
 
 This opens a browser window that prompts you to enter credentials, sign in to Google Auth Library and allow Google Auth Library to access your account. Accept the prompts. When it has completed, a credential JSON file is created in  
@@ -105,18 +105,18 @@ If you are prompted to install the Cloud Resource Manager API, press `y` to acce
 
 ### Start the Docker container with Cloud data {docker-data}
 
-#### Run with a prebuilt image 
+#### Run with a prebuilt image
 
-If you have not made changes that require a local build, and just want to run the pre-downloaded image, from `website` root of the repository,  run:
+If you have not made changes that require a local build, and just want to run the pre-downloaded image, from `website` root of the repository, run:
 
-```shell  
-docker run -it \  
---env-file $PWD/custom_dc/cloudsql_env.list \  
--p 8080:8080 \  
--e DEBUG=true \  
--e GOOGLE_APPLICATION_CREDENTIALS=/gcp/creds.json \  
--v $HOME/.config/gcloud/application_default_credentials.json:/gcp/creds.json:ro \  
-gcr.io/datcom-ci/datacommons-website-compose:stable  
+```shell
+docker run -it \
+--env-file $PWD/custom_dc/cloudsql_env.list \
+-p 8080:8080 \
+-e DEBUG=true \
+-e GOOGLE_APPLICATION_CREDENTIALS=/gcp/creds.json \
+-v $HOME/.config/gcloud/application_default_credentials.json:/gcp/creds.json:ro \
+gcr.io/datcom-ci/datacommons-website-compose:stable
 ```
 
 #### Run with a locally built repo
@@ -143,8 +143,8 @@ You can load the new/updated data from Cloud Storage using the `/admin` page on 
 
 1. Optionally, in the `cloudsql_env.list` file, set the `ADMIN_SECRET` environment variable to a string that authorizes users to load data.
 1. Start the Docker container as described above.
-1. With the services running, navigate to the `/admin` page. If a secret is required, enter it in the text field, and click **Load**. 
-This runs a script inside the Docker container, that converts the CSV data in Cloud Storage into SQL tables, and stores them in the Cloud SQL database you created earlier. It also generates embeddings in the Google Cloud Storage folder into which you uploaded the CSV/JSON files, in a `datacommons/nl/` subfolder. 
+1. With the services running, navigate to the `/admin` page. If a secret is required, enter it in the text field, and click **Load**.
+   This runs a script inside the Docker container, that converts the CSV data in Cloud Storage into SQL tables, and stores them in the Cloud SQL database you created earlier. It also generates embeddings in the Google Cloud Storage folder into which you uploaded the CSV/JSON files, in a `datacommons/nl/` subfolder.
 
 ## Inspect the Cloud SQL database
 
@@ -155,7 +155,7 @@ To view information about the created tables:
 1. In the **Sign in to SQL Studio** page, from the Database field, select the database you created earlier, e.g. `datacommons`.
 1. Enter the user name and password and click **Authenticate**.
 1. In the left Explorer pane that appears, expand the **Databases** icon, your database name, and **Tables**. The table of interest is `observations`. You can see column names and other metadata.
-1. To view the actual data, in the main window, click **New SQL Editor tab**. This opens an environment in which you can enter and run SQL queries. 
+1. To view the actual data, in the main window, click **New SQL Editor tab**. This opens an environment in which you can enter and run SQL queries.
 1. Enter a query and click **Run**. For example, for the sample OECD data, if you do `select * from observations limit 10;`, you should see output like this:
 
-    ![screenshot_sqlite](/assets/images/custom_dc/customdc_screenshot6.png){: height="400"}
+   ![screenshot_sqlite](/assets/images/custom_dc/customdc_screenshot6.png){: height="400"}

--- a/custom_dc/deploy_cloud.md
+++ b/custom_dc/deploy_cloud.md
@@ -2,7 +2,7 @@
 layout: default
 title: Deploy a custom instance to Google Cloud
 nav_order: 7
-parent:  Custom Data Commons
+parent: Custom Data Commons
 ---
 
 ## Deploy a custom instance to Google Cloud
@@ -11,7 +11,7 @@ When you are ready to launch your custom Data Commons site, we recommend hosting
 
 ![setup4](/assets/images/custom_dc/customdc_setup4.png)
 
-You push a locally built Docker image to the [Google Cloud Artifact Registry](https://cloud.google.com/artifact-registry), and then deploy the image in Cloud Run. 
+You push a locally built Docker image to the [Google Cloud Artifact Registry](https://cloud.google.com/artifact-registry), and then deploy the image in Cloud Run.
 
 ## One-time setup: Create a Google Artifact Registry repository
 
@@ -25,39 +25,40 @@ You push a locally built Docker image to the [Google Cloud Artifact Registry](ht
 
 ## Upload the Docker container to Google Cloud
 
-This procedure creates a "dev" Docker package that you upload to the Google Cloud Artifact Registry, and then deploy to Google Cloud Run. 
+This procedure creates a "dev" Docker package that you upload to the Google Cloud Artifact Registry, and then deploy to Google Cloud Run.
 
 1. Build a local version of the Docker image, following the procedure in [Build the local repo](/custom_dc/build_repo.html).
 1. Authenticate to gcloud:
 
-    ```shell  
-    gcloud auth login  
-    ```  
-    This opens a browser window that prompts you to enter credentials, sign in to Google Cloud SDK and allow Google Cloud SDK to access your account. Accept the prompts.
+   ```shell
+   gcloud auth login
+   ```
 
-1. Generate credentials for the Docker package you will build in the next step.  Docker package names must be in the format <code><var>LOCATION</var>-docker-pkg.dev</code>, where the _LOCATION_ is the region you have selected in the repository creation step previously; for example, `us-central1`.
+   This opens a browser window that prompts you to enter credentials, sign in to Google Cloud SDK and allow Google Cloud SDK to access your account. Accept the prompts.
+
+1. Generate credentials for the Docker package you will build in the next step. Docker package names must be in the format <code><var>LOCATION</var>-docker-pkg.dev</code>, where the _LOCATION_ is the region you have selected in the repository creation step previously; for example, `us-central1`.
 
     <pre>  
     gcloud auth configure-docker <var>LOCATION</var>-docker.pkg.dev  
    </pre>
 
-    When prompted to confirm creating the credentials file, click `Y` to accept.
+   When prompted to confirm creating the credentials file, click `Y` to accept.
 
-1. Build a target package from the source image in the previous step. The `_ARTIFACT_REPO`_ must be an Artifact Registry repository you have created previously. The `_IMAGE_NAME`_ may be the same as the source (`datacommons-website-compose`) or any other string. The _`TARGET_IMAGE_TAG`_ can be the same as the source or any other string. 
+1. Build a target package from the source image in the previous step. The `_ARTIFACT_REPO`_ must be an Artifact Registry repository you have created previously. The `_IMAGE_NAME`_ may be the same as the source (`datacommons-website-compose`) or any other string. The _`TARGET_IMAGE_TAG`_ can be the same as the source or any other string.
 
-     <pre> 
-    docker tag datacommons-website-compose:<var>DOCKER_TAG</var> \  
-    <var>LOCATION</var>-docker.pkg.dev/<var>PROJECT_ID</var>/<var>ARTIFACT_REPO</var>/<var>IMAGE_NAME</var>:<var>TARGET_IMAGE_TAG</var>  
-    </pre>
+ <pre> 
+docker tag datacommons-website-compose:<var>DOCKER_TAG</var> \  
+<var>LOCATION</var>-docker.pkg.dev/<var>PROJECT_ID</var>/<var>ARTIFACT_REPO</var>/<var>IMAGE_NAME</var>:<var>TARGET_IMAGE_TAG</var>  
+</pre>
 
 1. Push the image to the registry:
 
-    <pre>
-    docker push <var>LOCATION</var>-docker.pkg.dev/<var>PROJECT_ID</var>/<var>ARTIFACT_REPO</var>/<var>IMAGE_NAME</var>:<var>TARGET_IMAGE_TAG</var>  
-    </pre>
+<pre>
+docker push <var>LOCATION</var>-docker.pkg.dev/<var>PROJECT_ID</var>/<var>ARTIFACT_REPO</var>/<var>IMAGE_NAME</var>:<var>TARGET_IMAGE_TAG</var>  
+</pre>
 
-This will take several minutes to upload. 
-    
+This will take several minutes to upload.
+
 When it completes, verify that the container has been uploaded in the Cloud Console:
 
 1. Go to [https://console.cloud.google.com/artifacts](https://console.cloud.google.com/artifacts) for your project.
@@ -69,28 +70,28 @@ To deploy the image in Google Cloud Run, you need to create a Run service. Becau
 
 1. Copy the settings from the cloudsql_env.list file to a local environment variable:
 
-    ```shell  
-    env_vars=$(awk -F '=' 'NF==2 {print $1"="$2}' custom_dc/cloudsql_env.list | tr '\n' ',' | sed 's/,$//')  
-    ```
+   ```shell
+   env_vars=$(awk -F '=' 'NF==2 {print $1"="$2}' custom_dc/cloudsql_env.list | tr '\n' ',' | sed 's/,$//')
+   ```
 
-1. Create a new Cloud Run service and deploy the image in the Artifact Registry. 	`
+1. Create a new Cloud Run service and deploy the image in the Artifact Registry. `
 
-    <pre>
-    gcloud run deploy <var>SERVICE_NAME</var> \  
-    --allow-unauthenticated \  
-    --memory 8Gi \  
-    --cpu 2 \  
-    --region <var>LOCATION</var> \  
-    --image <var>LOCATION</var>-docker.pkg.dev/<var>PROJECT_ID</var>/<var>ARTIFACT_REPO</var>/<var>IMAGE_NAME</var>:<var>TARGET_IMAGE_TAG</var>  \
-    --add-cloudsql-instances=<var>PROJECT_ID</var>:<var>LOCATION</var>:<var>INSTANCE_ID</var> \  
-    --set-env-vars="$env_vars" \  
-    --port 8080  
-    --no-cpu-throttling
-    </pre>
+   <pre>
+   gcloud run deploy <var>SERVICE_NAME</var> \  
+   --allow-unauthenticated \  
+   --memory 8Gi \  
+   --cpu 2 \  
+   --region <var>LOCATION</var> \  
+   --image <var>LOCATION</var>-docker.pkg.dev/<var>PROJECT_ID</var>/<var>ARTIFACT_REPO</var>/<var>IMAGE_NAME</var>:<var>TARGET_IMAGE_TAG</var>  \
+   --add-cloudsql-instances=<var>PROJECT_ID</var>:<var>LOCATION</var>:<var>INSTANCE_ID</var> \  
+   --set-env-vars="$env_vars" \  
+   --port 8080  
+   --no-cpu-throttling
+   </pre>
 
-    The _SERVICE_NAME_ can be any string of your choice.
+   The _SERVICE_NAME_ can be any string of your choice.
 
-1. Follow the screen output to see the status details of the operation. Once it completes, a link to the deployed image is output. Visit the link in your browser to see the running instance. 
+1. Follow the screen output to see the status details of the operation. Once it completes, a link to the deployed image is output. Visit the link in your browser to see the running instance.
 
 To inspect the service in the Cloud Console:
 
@@ -106,5 +107,5 @@ See also [Deploying to Cloud Run](https://cloud.google.com/run/docs/deploying) f
 
 Once you have deployed a custom instance to Google Cloud, you can continue to update your custom data in two ways:
 
--  Load the data from a local running instance, as described in [Load custom data in Cloud SQL](/custom_dc/data_cloud.html#load-data-cloudsql)
--  Use the `/admin` page from the running Cloud app. 
+- Load the data from a local running instance, as described in [Load custom data in Cloud SQL](/custom_dc/data_cloud.html#load-data-cloudsql)
+- Use the `/admin` page from the running Cloud app.

--- a/custom_dc/index.md
+++ b/custom_dc/index.md
@@ -9,7 +9,7 @@ has_children: true
 
 Data Commons is an open source platform. Any organization can create a custom Data Commons instance with its own data, customized user interface and visualization tools,
 
-A custom instance natively combines the base Data Commons data (from datacommons.org) and the custom data in a unified fashion. Users can generate visualizations and perform data analyses across base and custom datasets seamlessly. 
+A custom instance natively combines the base Data Commons data (from datacommons.org) and the custom data in a unified fashion. Users can generate visualizations and perform data analyses across base and custom datasets seamlessly.
 
 A custom Data Commons site is deployed in Google Cloud Platform (GCP). The owner has full control over data, computing resources and access. The site can be accessible by the general public or can be controlled to limited principals. When base data is joined with the custom instance data, it is pulled in from the main Data Commons site; custom data is never pushed to the main site.
 
@@ -31,32 +31,32 @@ A custom Data Commons site is deployed in Google Cloud Platform (GCP). The owner
 
 If you have the resources to develop and maintain a custom Data Commons instance, this is a good option for the following use cases:
 
--  You want to add your own data to Data Commons but want to maintain ownership of the Cloud data.
--  You want to add your own data to Data Commons but want to customize the UI of the site.
--  You want to host your data on your own website, using the Data Commons tools. (You may also host all or part of your data on the main public Data Commons site as well.)
--  You want to add your own private data to Data Commons, and restrict access to it.
--  You want to host all or part of your data on your own the main public Data Commons site in additio
+- You want to add your own data to Data Commons but want to maintain ownership of the Cloud data.
+- You want to add your own data to Data Commons but want to customize the UI of the site.
+- You want to host your data on your own website, using the Data Commons tools. (You may also host all or part of your data on the main public Data Commons site as well.)
+- You want to add your own private data to Data Commons, and restrict access to it.
+- You want to host all or part of your data on your own the main public Data Commons site in additio
 
 Also, if you want to add all of your data to the main Data Commons and test how it will work with the exploration tools and natural language queries, you will need to at least host a local development site for testing purposes.
 
-For the following use cases, a custom Data Commons instance is not necessary: 
+For the following use cases, a custom Data Commons instance is not necessary:
 
--  You only want to make your own data available to the main public Data Commons site and don't need to test it. In this case, see the procedures in [Data imports](/import_dataset/index.html). 
--  You want to make the base public data or visualizations available in your own site. For this purpose, you can call the Data Commons APIs from your site; see [Data Commons web components](/api/web_components/index.html) for more details.
+- You only want to make your own data available to the main public Data Commons site and don't need to test it. In this case, see the procedures in [Data imports](/import_dataset/index.html).
+- You want to make the base public data or visualizations available in your own site. For this purpose, you can call the Data Commons APIs from your site; see [Data Commons web components](/api/web_components/index.html) for more details.
 
 ## Supported features
 
 A custom Data Commons instance supports the following features:
 
--  All of the same interactive tools as the main site, including the natural language query interface
--  REST APIs --- no additional setup neeeded
--  Python and Pandas API wrappers, and/or Spreadsheets --- requires additional setup and maintenance. If you would like to support these facilities, please contact us.
--  Access controls to the site, using any supported Google Cloud Run mechanisms, such as Virtual Private Cloud, Cloud IAM, and so on. Please see the GCP [Restricting ingress for Cloud Run](https://cloud.google.com/run/docs/securing/ingress) for more information on these options.
+- All of the same interactive tools as the main site, including the natural language query interface
+- REST APIs --- no additional setup neeeded
+- Python and Pandas API wrappers, and/or Spreadsheets --- requires additional setup and maintenance. If you would like to support these facilities, please contact us.
+- Access controls to the site, using any supported Google Cloud Run mechanisms, such as Virtual Private Cloud, Cloud IAM, and so on. Please see the GCP [Restricting ingress for Cloud Run](https://cloud.google.com/run/docs/securing/ingress) for more information on these options.
 
 The following are not supported:
 
--  Fine-grained data access controls; you cannot set access controls on specific data, only the entire custom site.
--  Bigquery APIs
+- Fine-grained data access controls; you cannot set access controls on specific data, only the entire custom site.
+- Bigquery APIs
 
 ## System overview
 
@@ -66,10 +66,10 @@ Essentially, a custom Data Commons instance is a mirror of the public Data Commo
 
 The custom Data Commons Docker container consists of the following components:
 
--  A [Nginx reverse proxy server](https://www.nginx.com/resources/glossary/reverse-proxy-server/), which routes incoming requests to the web or API server
--  A Python-Flask web server, which handles interactive requests from users
--  An Python-Flask NL server, for generating embeddings and serving natural language queries
--  A Go Mixer, also known as the API server, which serves programmatic requests using Data Commons APIs. The SQL query engine is built into the Mixer, which sends queries to both the local and remote data stores to find the right data. If the Mixer determines that it cannot fully resolve a user query from the custom data, it will make an REST API call, as an anonymous "user" to the base Data Commons Mixer and data.
+- A [Nginx reverse proxy server](https://www.nginx.com/resources/glossary/reverse-proxy-server/), which routes incoming requests to the web or API server
+- A Python-Flask web server, which handles interactive requests from users
+- An Python-Flask NL server, for generating embeddings and serving natural language queries
+- A Go Mixer, also known as the API server, which serves programmatic requests using Data Commons APIs. The SQL query engine is built into the Mixer, which sends queries to both the local and remote data stores to find the right data. If the Mixer determines that it cannot fully resolve a user query from the custom data, it will make an REST API call, as an anonymous "user" to the base Data Commons Mixer and data.
 
 In addition to the Docker container, a custom Data Commons instance uses custom data that you provide as raw CSV files. The web server calls an importer script that converts the CSV data into the Data Commons format and stores this in a SQL database. For local development, we provide a lightweight, open-source [SQLite](http://sqlite.org) database; for production, we recommend that you use [Google Cloud SQL](https://cloud.google.com/sql/).
 
@@ -77,19 +77,19 @@ In addition to the Docker container, a custom Data Commons instance uses custom 
 
 A custom Data Commons site runs in a Docker container on Google Cloud Platform (GCP). You will need the following:
 
--  A [GCP](http://console.cloud.google.com) billing account and project
--  A [Docker](http://docker.com) account 
--  If you will be customizing the site's UI, familiarity with the Python [Flask](https://flask.palletsprojects.com/en/3.0.x/#) web framework and [Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/) HTML templating
+- A [GCP](http://console.cloud.google.com) billing account and project
+- A [Docker](http://docker.com) account
+- If you will be customizing the site's UI, familiarity with the Python [Flask](https://flask.palletsprojects.com/en/3.0.x/#) web framework and [Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/) HTML templating
 
 If you already have an account with another cloud provider, we can provide a connector; please contact us if you are interested in this option.
 
-In terms of development time and effort, to launch a site with custom data in compatible format and no UI customization, you can expect it to take less than three weeks. If you need substantial UI customization it may take up to four months. 
+In terms of development time and effort, to launch a site with custom data in compatible format and no UI customization, you can expect it to take less than three weeks. If you need substantial UI customization it may take up to four months.
 
-The cost of running a site on Google Cloud Platform depends on the size of your data, the traffic you expect to receive, and the amount of geographical replication you want. For a small dataset, we have found the cost comes out to roughly $100 per year. You can get more precise information and cost estimation tools at [Google Cloud pricing](https://cloud.google.com/pricing). 
+The cost of running a site on Google Cloud Platform depends on the size of your data, the traffic you expect to receive, and the amount of geographical replication you want. For a small dataset, we have found the cost comes out to roughly $100 per year. You can get more precise information and cost estimation tools at [Google Cloud pricing](https://cloud.google.com/pricing).
 
 ## Recommended workflow
 
-1. Work through the [Quickstart](/custom_dc/quickstart.html) page to learn how to run a local Data Commons instance and load some sample custom data. 
+1. Work through the [Quickstart](/custom_dc/quickstart.html) page to learn how to run a local Data Commons instance and load some sample custom data.
 1. Prepare your real-world custom data and load it in the local custom instance. Data Commons requires your data to be in a specific format. See [Work with custom data](/custom_dc/custom_data.html). If you are just testing custom data to add to the main Data Commons site, this is all you need to do.
 1. If you are launching your own Data Commons site, and want to customize the look of the feel of the site, see [Customize the site](/custom_dc/custom_ui.html).
 1. If you are launching your own Data Commons site, upload your data to Google Cloud Platform and continue to use the local instance to test and validate the site. We recommend using Google Cloud Storage to store your data, and Google Cloud SQL to receive SQL queries from the local servers. See [Test data in Google Cloud](/custom_dc/data_cloud.html).

--- a/custom_dc/quickstart.md
+++ b/custom_dc/quickstart.md
@@ -7,7 +7,7 @@ parent: Custom Data Commons
 
 ## Quickstart
 
-To start developing a custom Data Commons instance, we recommend that you develop your site and host your data locally. This uses a SQLite database to store custom data. 
+To start developing a custom Data Commons instance, we recommend that you develop your site and host your data locally. This uses a SQLite database to store custom data.
 
 ![setup2](/assets/images/custom_dc/customdc_setup2.png)
 
@@ -15,11 +15,11 @@ This page shows you how to run a local custom Data Commons instance inside a Doc
 
 ## Prerequisites
 
--  Obtain a [GCP](https://console.cloud.google.com/welcome) billing account and project.
--  Install [Docker Engine](https://docs.docker.com/engine/install/).
--  Install [Git](https://git-scm.com/). 
--  Get an API key for Data Commons by submitting the [Data Commons API key request form](https://docs.google.com/forms/d/e/1FAIpQLSePrkVfss9lUIHFClQsVPwPcAVWvX7WaZZyZjJWS99wRQNW4Q/viewform?resourcekey=0-euQU6Kly7YIWVRNS2p4zjw). The key is needed to authorize requests from your custom site to the main Data Commons site. Typical turnaround times are 24-48 hours. 
--  Optional: Get a [Github](http://github.com) account, if you would like to browse the Data Commons source repos using your browser.
+- Obtain a [GCP](https://console.cloud.google.com/welcome) billing account and project.
+- Install [Docker Engine](https://docs.docker.com/engine/install/).
+- Install [Git](https://git-scm.com/).
+- Get an API key for Data Commons by submitting the [Data Commons API key request form](https://docs.google.com/forms/d/e/1FAIpQLSePrkVfss9lUIHFClQsVPwPcAVWvX7WaZZyZjJWS99wRQNW4Q/viewform?resourcekey=0-euQU6Kly7YIWVRNS2p4zjw). The key is needed to authorize requests from your custom site to the main Data Commons site. Typical turnaround times are 24-48 hours.
+- Optional: Get a [Github](http://github.com) account, if you would like to browse the Data Commons source repos using your browser.
 
 ## One-time setup steps
 
@@ -28,7 +28,7 @@ This page shows you how to run a local custom Data Commons instance inside a Doc
 1. Go to [https://console.cloud.google.com/apis/dashboard](https://console.cloud.google.com/apis/dashboard) for your project.
 1. Click **Enable APIs & Services**.
 1. Under **Maps**, enable **Places API** and **Maps Javascript API**.
-1. Go to [https://console.cloud.google.com/google/maps-apis/credentials](https://console.cloud.google.com/google/maps-apis/credentials) for your project. 
+1. Go to [https://console.cloud.google.com/google/maps-apis/credentials](https://console.cloud.google.com/google/maps-apis/credentials) for your project.
 1. Click **Create Credentials** > **API Key**.
 1. Record the key and click **Close**.
 1. Click on the newly created key to open the **Edit API Key** window.
@@ -36,27 +36,28 @@ This page shows you how to run a local custom Data Commons instance inside a Doc
 1. From the drop-down menu, enable Places API and Maps Javascript API. (Optionally enable other APIs for which you want to use this key.)
 1. Click **OK** and **Save**.
 
-### Clone the Data Commons repository 
+### Clone the Data Commons repository
 
 1. Open a terminal window, and go to a directory to which you would like to download the Data Commons repository.
-1. Clone the website Data Commons repository: 
+1. Clone the website Data Commons repository:
 
-    ```shell  
-    git clone https://github.com/datacommonsorg/website.git  
-    ```
-  This creates a local `website` subdirectory.
+   ```shell
+   git clone https://github.com/datacommonsorg/website.git
+   ```
+
+   This creates a local `website` subdirectory.
 
 1. When the downloads are complete, navigate to the root directory of the repo, `website`. References to various files and commands in these procedures are relative to this root.
 
-    ```shell  
-    cd website  
-    ```
+   ```shell
+   cd website
+   ```
 
 ### Set API keys as environment variables
 
 1. Using your favorite editor, open `custom_dc/sqlite_env.list`.
-1. Enter the relevant values for `DC_API_KEY` and `MAPS_API_KEY`. 
-1. Leave `ADMIN_SECRET` blank for now. 
+1. Enter the relevant values for `DC_API_KEY` and `MAPS_API_KEY`.
+1. Leave `ADMIN_SECRET` blank for now.
 
 Warning: Do not use any quotes (single or double) or spaces when specifying the values.
 
@@ -99,42 +100,43 @@ Warning: Do not use any quotes (single or double) or spaces when specifying the 
 
 ## Start the services
 
-From the root directory, `website`, run Docker as follows. 
+From the root directory, `website`, run Docker as follows.
 
 Note: If you are running on Linux, depending on whether you have created a ["sudoless" Docker group](https://docs.docker.com/engine/install/linux-postinstall/), you will need to preface every `docker` invocation with `sudo`.
 
-```shell  
-docker run -it \  
+```shell
+docker run -it \
 --pull=always \
--p 8080:8080 \  
--e DEBUG=true \  
---env-file $PWD/custom_dc/sqlite_env.list \  
--v $PWD/custom_dc/sample:/userdata \  
-gcr.io/datcom-ci/datacommons-website-compose:stable  
+-p 8080:8080 \
+-e DEBUG=true \
+--env-file $PWD/custom_dc/sqlite_env.list \
+-v $PWD/custom_dc/sample:/userdata \
+gcr.io/datcom-ci/datacommons-website-compose:stable
 ```
 
 This command does the following:
 
--  The first time you run it, downloads the latest stable Data Commons image, `gcr.io/datcom-ci/datacommons-website-compose:stable`, from the Google Cloud Artifact Registry, which may take a few minutes. Subsequent runs use the locally stored image.
--  Starts a Docker container in interactive mode. 
--  Starts development/debug versions of the Web Server, NL Server, and Mixer, as well as the Nginx proxy, inside the container
--  Maps the sample data to the Docker path `/userdata`, so the servers do not need to be restarted when you load the sample data
+- The first time you run it, downloads the latest stable Data Commons image, `gcr.io/datcom-ci/datacommons-website-compose:stable`, from the Google Cloud Artifact Registry, which may take a few minutes. Subsequent runs use the locally stored image.
+- Starts a Docker container in interactive mode.
+- Starts development/debug versions of the Web Server, NL Server, and Mixer, as well as the Nginx proxy, inside the container
+- Maps the sample data to the Docker path `/userdata`, so the servers do not need to be restarted when you load the sample data
 
 ### Stop and restart the services
 
 If you need to restart the services for any reason, do the following:
 
-1. In the terminal window where the services are running, press Ctrl-c to kill the Docker container. 
+1. In the terminal window where the services are running, press Ctrl-c to kill the Docker container.
 1. Rerun the `docker run` command as usual.
 
 Tip: If you close the terminal window in which you started the Docker container, you can kill it as follows:
 
 1. Open another terminal window, and from the `website` directory, get the Docker container ID.
 
-	```shell  
-    docker ps  
-    ```  
-  The `CONTAINER ID` is the first column in the output.
+   ```shell
+     docker ps
+   ```
+
+   The `CONTAINER ID` is the first column in the output.
 
 1. Run:
 
@@ -144,7 +146,7 @@ Tip: If you close the terminal window in which you started the Docker container,
 
 ## View the local website
 
-Once Docker is up and running, visit your local instance by pointing your browser to [http://localhost:8080](http://localhost:8080).  You should see something like this:
+Once Docker is up and running, visit your local instance by pointing your browser to [http://localhost:8080](http://localhost:8080). You should see something like this:
 
 ![screenshot_homepage](/assets/images/custom_dc/customdc_screenshot1.png){: width="900"}
 
@@ -152,23 +154,23 @@ You can browse the various Data Commons tools (Variables, Map, Timelines, etc.) 
 
 ## Load sample data
 
-In this step, we will add sample data that we have included as part of the download for you to load it into your custom instance. This data is from the Organisation for Economic Co-operation and Development (OECD): "per country data for annual average wages" and "gender wage gaps". 
+In this step, we will add sample data that we have included as part of the download for you to load it into your custom instance. This data is from the Organisation for Economic Co-operation and Development (OECD): "per country data for annual average wages" and "gender wage gaps".
 
 To load and view the sample data:
 
 1. Point your browser to the admin page at [http://localhost:8080/admin](http://localhost:8080/admin).
-1. Since you have not yet specified an `ADMIN_SECRET`, leave it blank. 
+1. Since you have not yet specified an `ADMIN_SECRET`, leave it blank.
 1. Click **Load Data**. It may take a few seconds to load.
 
 This does the following:
 
--  Imports the data from the CSV files, resolves entities, and writes the data to a SQLite database file, `custom_dc/sample/datacommons/datacommons.db`. 
--  Generates embeddings in the Docker image and loads them. 
+- Imports the data from the CSV files, resolves entities, and writes the data to a SQLite database file, `custom_dc/sample/datacommons/datacommons.db`.
+- Generates embeddings in the Docker image and loads them.
 
 Tip: When you restart the Docker instance, all data in the SQLite database is lost. If you want to preserve the sample data and have it automatically always load after restarting your Docker instance, without having to run the load data function each time, include this additional flag in your Docker run command:
 
-```shell  
--v $PWD/custom_dc/sample/datacommons:/sqlite  
+```shell
+-v $PWD/custom_dc/sample/datacommons:/sqlite
 ```
 
 Now visit the Timeline explorer at [http://localhost:8080/tools/timeline](http://localhost:8080/tools/timeline). You'll now see the new variables and can explore the new data. Try entering a country:
@@ -185,8 +187,8 @@ Note that NL support increases the startup time of your server and consumes more
 
 A custom instance can accept REST API requests at the endpoint `/core/api/v2/`. To try it out, here's an example request that returns the same data as in the interactive queries above, using the `observation` API. You can enter this query in your browser to get nice output:
 
-```  
-[http://localhost:8080/core/api/v2/observation?entity.dcids=country%2FCAN&select=entity&select=variable&select=value&select=date&variable.dcids=average_annual_wage](http://localhost:8080/core/api/v2/observation?entity.dcids=country%2FCAN&select=entity&select=variable&select=value&select=date&variable.dcids=average_annual_wage)  
+```
+[http://localhost:8080/core/api/v2/observation?entity.dcids=country%2FCAN&select=entity&select=variable&select=value&select=date&variable.dcids=average_annual_wage](http://localhost:8080/core/api/v2/observation?entity.dcids=country%2FCAN&select=entity&select=variable&select=value&select=date&variable.dcids=average_annual_wage)
 ```
 
 Note: You do not need to specify an API key as a parameter.

--- a/custom_dc/troubleshooting.md
+++ b/custom_dc/troubleshooting.md
@@ -2,7 +2,7 @@
 layout: default
 title: Troubleshooting
 nav_order: 8
-parent:  Custom Data Commons
+parent: Custom Data Commons
 ---
 
 ## Troubleshooting
@@ -17,6 +17,7 @@ If you see this error:
 docker: Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: ...
 dial unix /var/run/docker.sock: connect: permission denied.
 ```
+
 or this:
 
 ```
@@ -26,7 +27,6 @@ docker: Error response from daemon: pull access denied for datacommons-website-c
 1. Use `sudo` with your `docker` invocations or set up a "sudoless" docker group, as described in [Linux post-installation steps for Docker Engine](https://docs.docker.com/engine/install/linux-postinstall/).
 1. If you've just installed Docker, try rebooting the machine.
 
-
 ### Local build errors
 
 #### "file not found in build context"
@@ -34,7 +34,7 @@ docker: Error response from daemon: pull access denied for datacommons-website-c
 If you are building a local instance and get this error:
 
 ```
-Step 7/62 : COPY mixer/go.mod mixer/go.sum ./  
+Step 7/62 : COPY mixer/go.mod mixer/go.sum ./
 COPY failed: file not found in build context or excluded by .dockerignore: stat mixer/go.mod: file does not exist
 ```
 
@@ -44,10 +44,9 @@ You need to download/update additional submodules (derived from other repos). Se
 
 If you try to load data using the `/admin page`, and see the following errors:
 
-`Error running import` or  `invalid input`
+`Error running import` or `invalid input`
 
 There is a problem with how you have set up your CSV files and/or config.json file. Check that your CSV files conform to the structure described in [Prepare the CSV files](/custom_dc/custom_data.html#prepare-csv).
-
 
 If the load page does not show any errors but data still does not load, try checking the following:
 
@@ -66,14 +65,13 @@ If you try to enter input into any of the explorer tools fields, and you get thi
 
 This is because you are missing a valid API key or the necessary APIs are not enabled. Follow procedures in [Enable Google Cloud APIs and get a Maps API key](/custom_dc/quickstart.html#maps-key), and be sure to obtain a permanent Maps/Places API key.
 
-
 ### Cloud Run Service problems
 
-In general, whenever you encounter problems with any Google Cloud Run service, check the **Logs** page for your Cloud Run service, to get detailed output from the services. 
+In general, whenever you encounter problems with any Google Cloud Run service, check the **Logs** page for your Cloud Run service, to get detailed output from the services.
 
-#### "502 Bad Gateway" 
+#### "502 Bad Gateway"
 
 If you see no errors in the logs, except `connect() failed (111: Connection refused) while connecting to upstream`, try the following:
 
 1. Wait a few minutes and try to access the app again. Sometimes it appears to be deployed, but some of the services haven't yet started up.
-1. In the Cloud Run **Service details** page, click the **Revisions** tab. Under the **Containers** tab, under **General**, check that **CPU Allocation** is set to **CPU is always allocated**. If it is not, click **Edit & Deploy New Revision**, and the **Containers** tab. Under **CPU allocation and pricing** enable **CPU is always allocated** and click **Deploy**. 
+1. In the Cloud Run **Service details** page, click the **Revisions** tab. Under the **Containers** tab, under **General**, check that **CPU Allocation** is set to **CPU is always allocated**. If it is not, click **Edit & Deploy New Revision**, and the **Containers** tab. Under **CPU allocation and pricing** enable **CPU is always allocated** and click **Deploy**.


### PR DESCRIPTION
 Going through the custom DC quick start, I was running into errors when copying and pasting some of the docker commands due to some trailing whitespace at the end of the line

Example:
```
<pre>
docker run -it \  
-p 8080:8080 \  
-e DEBUG=true \  
--env-file $PWD/custom_dc/sqlite_env.list \  
-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>:/userdata \  
[-v $PWD/custom_dc/<var>CUSTOM_DATA_DIRECTORY</var>/datacommons:/sqlite]  
gcr.io/datcom-ci/datacommons-website-compose:stable  
</pre>
```

The trailing whitespace after the `\` character causes an error when pasting into a bash shell.


Fix: Applied vscode "prettier" formatting to custom dc markdown files, which, among other formatting fixes, removes extra whitespace before newlines

Steps:
(1) install prettier extension in vs code (open "extensions" tab, search "prettier", install)
(2) enable "format on save option" in vs code preferences (command+shift+p -> type "Preferences: Open User Settings" -> search "Format on Save" -> enable)

