### PR TITLE
redirect to blog.datacommons.org

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,7 +81,7 @@
               <div class="dropdown-menu" aria-labelledby="nav-about-dropdown">
                 <a class="dropdown-item" href="https://datacommons.org/about">About Data
                   Commons</a>
-                <a class="dropdown-item" href="https://blogs.datacommons.org/">Blog</a>
+                <a class="dropdown-item" href="https://blog.datacommons.org/">Blog</a>
                 <a class="dropdown-item" href="https://datacommons.org/datasets">Data
                   Sources</a>
                 <a class="dropdown-item" href="https://datacommons.org/faq">FAQ</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,7 +81,7 @@
               <div class="dropdown-menu" aria-labelledby="nav-about-dropdown">
                 <a class="dropdown-item" href="https://datacommons.org/about">About Data
                   Commons</a>
-                <a class="dropdown-item" href="/blog.html">Blog</a>
+                <a class="dropdown-item" href="https://blogs.datacommons.org/">Blog</a>
                 <a class="dropdown-item" href="https://datacommons.org/datasets">Data
                   Sources</a>
                 <a class="dropdown-item" href="https://datacommons.org/faq">FAQ</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-<h3><a href="/blog.html">Blog</a></h3>
+<h3><a href="https://blog.datacommons.org/">Blog</a></h3>
 
 <h3 class=blog-byline>
   {{ page.date | date_to_string }}&nbsp;&#8211;&nbsp;{{ page.author }}</h3>

--- a/blog.html
+++ b/blog.html
@@ -1,17 +1,5 @@
 ---
-layout: default
+layout: redirect
 title: Blog
+redirect: https://blog.datacommons.org/
 ---
-<h1>Blog</h1>
-
-<ul class="blog-posts">
-  {% for post in site.posts %}
-  <li>
-    <h3 class="blog-byline">
-      {{ post.date | date_to_string }}&nbsp;&#8211;&nbsp;{{ post.author }}
-    </h3>
-    <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
-    {{ post.content }}
-  </li>
-  {% endfor %}
-</ul>


### PR DESCRIPTION
Add redirects from our old blog to the new wordpress site.