### PR TITLE
Added docs for connecting datacommons-bar component to datacommons-slider

### DIFF
--- a/api/web_components/bar.md
+++ b/api/web_components/bar.md
@@ -33,6 +33,7 @@ permalink: /api/web_components/bar
   maxPlaces="15"
 ></datacommons-bar>
 ```
+
 {: #multi-place .api-tabcontent}
 
 ```html
@@ -44,6 +45,7 @@ permalink: /api/web_components/bar
   maxPlaces="15"
 ></datacommons-bar>
 ```
+
 {: #contained-in .api-tabcontent}
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -53,39 +55,43 @@ permalink: /api/web_components/bar
 
 ### Required
 
-| Name           | Type   | Description                                                                                                                                                                                   |
-| -------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| childPlaceType | string | Child place types to plot. Example: `State`. For a list of available place types, see the [place types page](/place_types.html).<br /><optional-tag>Optional</optional-tag> if `places` is specified.                                                                           |
-| header         | string | Chart title.                                                                                                                                                                                  |
+| Name           | Type   | Description                                                                                                                                                                                                          |
+| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| childPlaceType | string | Child place types to plot. Example: `State`. For a list of available place types, see the [place types page](/place_types.html).<br /><optional-tag>Optional</optional-tag> if `places` is specified.                |
+| header         | string | Chart title.                                                                                                                                                                                                         |
 | parentPlace    | string | Parent place [DCID](/glossary.html#dcid) to plot. Example: `country/USA`. <br /> <optional-tag>Optional</optional-tag> if `places` is specified.                                                                     |
 | places         | list   | Places [DCID](/glossary.html#dcid)s to plot, as a space separated list of strings. Example: `"geoId/12 geoId/13"`. <br /> <optional-tag>Optional</optional-tag> if `childPlaceType` and `parentPlace` are specified. |
 | variables      | list   | Variable [DCID](/glossary.html#dcid)(s) to plot, as a space separated list of strings. Example: `"Count_Person Count_Farm"`.                                                                                         |
+
 {: .doc-table }
 
 ### Optional
 
-| Name       | Type    | Description                                                                                                                                                                                                                                                                                                                                                             |
-| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| barHeight  | number  | Bar height (in px) for horizontal charts.                                                                                                                                                                                                                                                                                                                               |
-| colors     | list    | Specify custom color for each variable. Pass in colors in the same order as variables.<br /><br />Values should follow CSS specification (keywords, rgb, rgba, hsl, #hex). Separate multiple values with spaces, e.g., `"#ff0000 #00ff00 #0000ff"`. Make sure individual colors have no spaces. For example, use `rgba(255,0,0,0.3)` instead of `rgba(255, 0, 0, 0.3)`. |
-| horizontal | boolean | Include to draw bars horizontally instead of vertically.                                                                                                                                                                                                                                                                                                                |
-| lollipop   | boolean | Include to draw lollipops instead of bars.                                                                                                                                                                                                                                                                                                                              |
-| maxPlaces  | number  | Maximum _number_ of child places to plot. Default: `7`.                                                                                                                                                                                                                                                                                                                 |
-| maxVariables  | number  | Maximum _number_ of varibales to plot. Default: show all variables.                                                                                                                                                                                                                                                                                                                 |
-| sort       | string  | Bar chart sort order. <br/><br/>Options: <br /> - `ascending` (ascending by the variable's value)<br /> - `descending` (descending by variable's value)<br /> - `ascendingPopulation` (ascending by the place's population)<br /> -`descendingPopulation` (descending by the place's population)<br /><br />Default: `descendingPopulation`                   |
-| stacked    | boolean | Include to draw as stacked bar chart instead of grouped chart.                                                                                                                                                                                                                                                                                                          |
+| Name         | Type    | Description                                                                                                                                                                                                                                                                                                                                                             |
+| ------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| barHeight    | number  | Bar height (in px) for horizontal charts.                                                                                                                                                                                                                                                                                                                               |
+| colors       | list    | Specify custom color for each variable. Pass in colors in the same order as variables.<br /><br />Values should follow CSS specification (keywords, rgb, rgba, hsl, #hex). Separate multiple values with spaces, e.g., `"#ff0000 #00ff00 #0000ff"`. Make sure individual colors have no spaces. For example, use `rgba(255,0,0,0.3)` instead of `rgba(255, 0, 0, 0.3)`. |
+| horizontal   | boolean | Include to draw bars horizontally instead of vertically.                                                                                                                                                                                                                                                                                                                |
+| lollipop     | boolean | Include to draw lollipops instead of bars.                                                                                                                                                                                                                                                                                                                              |
+| maxPlaces    | number  | Maximum _number_ of child places to plot. Default: `7`.                                                                                                                                                                                                                                                                                                                 |
+| maxVariables | number  | Maximum _number_ of varibales to plot. Default: show all variables.                                                                                                                                                                                                                                                                                                     |
+| sort         | string  | Bar chart sort order. <br/><br/>Options: <br /> - `ascending` (ascending by the variable's value)<br /> - `descending` (descending by variable's value)<br /> - `ascendingPopulation` (ascending by the place's population)<br /> -`descendingPopulation` (descending by the place's population)<br /><br />Default: `descendingPopulation`                             |
+| stacked      | boolean | Include to draw as stacked bar chart instead of grouped chart.                                                                                                                                                                                                                                                                                                          |
+| subscribe    | string  | Listen for data changes on this event channel. Channel name should match the `publish` name on a control component. Example: [datacommons-slider](./slider.md)                                                                                                                                                                                                          |
+
 {: .doc-table }
 
 ### Advanced Configuration
 
-| Name                | Type   | Description                                                                                                                                                                                                                                                                                |
-| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| apiRoot         | string  | Domain to make data fetch API calls from. Used primarily for fetching data from custom DCs.<br /><br />Default: `https://datacommons.org`. |
-| defaultVariableName | string | To be used with `variableNameRegex`. If specified and no variable name is extracted out with the regex, use this as the variable name. e.g., if the variableNameRegex is "(.*?)(?=:)", and the defaultVariableName is "Total", for a variable named "variable 1", it will become "Total". |
-| placeNameProp   | string  | Optionally specify the property to use to get the place names.                                                                             |
-| showExploreMore | boolean | Include to show "Explore more" link in the footer, which takes the user to Datacommons.org's [visualization tools](https://datacommons.org/tools/visualization).                                        |
-| variableNameRegex   | string | Optionally specify regex to use to extract out variable name. e.g., if the variableNameRegex is "(.*?)(?=:)", only the part before a ":" will be used for variable names. So "variable 1: test" will become "variable 1".                                                                  |
-| yAxisMargin | number | Set size (in px) of y-axis' margin to fit the axis label text. Default: 60px. |
+| Name                | Type    | Description                                                                                                                                                                                                                                                                                |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| apiRoot             | string  | Domain to make data fetch API calls from. Used primarily for fetching data from custom DCs.<br /><br />Default: `https://datacommons.org`.                                                                                                                                                 |
+| defaultVariableName | string  | To be used with `variableNameRegex`. If specified and no variable name is extracted out with the regex, use this as the variable name. e.g., if the variableNameRegex is "(.\*?)(?=:)", and the defaultVariableName is "Total", for a variable named "variable 1", it will become "Total". |
+| placeNameProp       | string  | Optionally specify the property to use to get the place names.                                                                                                                                                                                                                             |
+| showExploreMore     | boolean | Include to show "Explore more" link in the footer, which takes the user to Datacommons.org's [visualization tools](https://datacommons.org/tools/visualization).                                                                                                                           |
+| variableNameRegex   | string  | Optionally specify regex to use to extract out variable name. e.g., if the variableNameRegex is "(.\*?)(?=:)", only the part before a ":" will be used for variable names. So "variable 1: test" will become "variable 1".                                                                 |
+| yAxisMargin         | number  | Set size (in px) of y-axis' margin to fit the axis label text. Default: 60px.                                                                                                                                                                                                              |
+
 {: .doc-table }
 
 ## Examples
@@ -94,6 +100,7 @@ permalink: /api/web_components/bar
 
 Code:
 {: .example-box-title}
+
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -102,6 +109,7 @@ Code:
   variables="Count_Person"
 ></datacommons-bar>
 ```
+
 {: .example-box-content}
 
 <div>
@@ -118,6 +126,7 @@ Code:
 
 Code:
 {: .example-box-title}
+
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -125,6 +134,7 @@ Code:
   places="geoId/01 geoId/02"
 ></datacommons-bar>
 ```
+
 {: .example-box-content}
 
 <div>
@@ -140,6 +150,7 @@ Code:
 
 Code:
 {: .example-box-title}
+
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -148,6 +159,7 @@ Code:
   stacked
 ></datacommons-bar>
 ```
+
 {: .example-box-content}
 
 <div>
@@ -164,6 +176,7 @@ Code:
 
 Code:
 {: .example-box-title}
+
 ```html
 <datacommons-bar
   header="Median income by gender"
@@ -174,6 +187,7 @@ Code:
   sort="descending"
 ></datacommons-bar>
 ```
+
 {: .example-box-content}
 
 <div>
@@ -192,6 +206,7 @@ Code:
 
 Code:
 {: .example-box-title}
+
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -201,6 +216,7 @@ Code:
   lollipop
 ></datacommons-bar>
 ```
+
 {: .example-box-content}
 
 <div>

--- a/api/web_components/bar.md
+++ b/api/web_components/bar.md
@@ -33,7 +33,6 @@ permalink: /api/web_components/bar
   maxPlaces="15"
 ></datacommons-bar>
 ```
-
 {: #multi-place .api-tabcontent}
 
 ```html
@@ -45,7 +44,6 @@ permalink: /api/web_components/bar
   maxPlaces="15"
 ></datacommons-bar>
 ```
-
 {: #contained-in .api-tabcontent}
 
 <script src="/assets/js/syntax_highlighting.js"></script>
@@ -55,43 +53,40 @@ permalink: /api/web_components/bar
 
 ### Required
 
-| Name           | Type   | Description                                                                                                                                                                                                          |
-| -------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| childPlaceType | string | Child place types to plot. Example: `State`. For a list of available place types, see the [place types page](/place_types.html).<br /><optional-tag>Optional</optional-tag> if `places` is specified.                |
-| header         | string | Chart title.                                                                                                                                                                                                         |
+| Name           | Type   | Description                                                                                                                                                                                   |
+| -------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| childPlaceType | string | Child place types to plot. Example: `State`. For a list of available place types, see the [place types page](/place_types.html).<br /><optional-tag>Optional</optional-tag> if `places` is specified.                                                                           |
+| header         | string | Chart title.                                                                                                                                                                                  |
 | parentPlace    | string | Parent place [DCID](/glossary.html#dcid) to plot. Example: `country/USA`. <br /> <optional-tag>Optional</optional-tag> if `places` is specified.                                                                     |
 | places         | list   | Places [DCID](/glossary.html#dcid)s to plot, as a space separated list of strings. Example: `"geoId/12 geoId/13"`. <br /> <optional-tag>Optional</optional-tag> if `childPlaceType` and `parentPlace` are specified. |
 | variables      | list   | Variable [DCID](/glossary.html#dcid)(s) to plot, as a space separated list of strings. Example: `"Count_Person Count_Farm"`.                                                                                         |
-
 {: .doc-table }
 
 ### Optional
 
-| Name         | Type    | Description                                                                                                                                                                                                                                                                                                                                                             |
-| ------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| barHeight    | number  | Bar height (in px) for horizontal charts.                                                                                                                                                                                                                                                                                                                               |
-| colors       | list    | Specify custom color for each variable. Pass in colors in the same order as variables.<br /><br />Values should follow CSS specification (keywords, rgb, rgba, hsl, #hex). Separate multiple values with spaces, e.g., `"#ff0000 #00ff00 #0000ff"`. Make sure individual colors have no spaces. For example, use `rgba(255,0,0,0.3)` instead of `rgba(255, 0, 0, 0.3)`. |
-| horizontal   | boolean | Include to draw bars horizontally instead of vertically.                                                                                                                                                                                                                                                                                                                |
-| lollipop     | boolean | Include to draw lollipops instead of bars.                                                                                                                                                                                                                                                                                                                              |
-| maxPlaces    | number  | Maximum _number_ of child places to plot. Default: `7`.                                                                                                                                                                                                                                                                                                                 |
-| maxVariables | number  | Maximum _number_ of varibales to plot. Default: show all variables.                                                                                                                                                                                                                                                                                                     |
-| sort         | string  | Bar chart sort order. <br/><br/>Options: <br /> - `ascending` (ascending by the variable's value)<br /> - `descending` (descending by variable's value)<br /> - `ascendingPopulation` (ascending by the place's population)<br /> -`descendingPopulation` (descending by the place's population)<br /><br />Default: `descendingPopulation`                             |
-| stacked      | boolean | Include to draw as stacked bar chart instead of grouped chart.                                                                                                                                                                                                                                                                                                          |
+| Name       | Type    | Description                                                                                                                                                                                                                                                                                                                                                             |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| barHeight  | number  | Bar height (in px) for horizontal charts.                                                                                                                                                                                                                                                                                                                               |
+| colors     | list    | Specify custom color for each variable. Pass in colors in the same order as variables.<br /><br />Values should follow CSS specification (keywords, rgb, rgba, hsl, #hex). Separate multiple values with spaces, e.g., `"#ff0000 #00ff00 #0000ff"`. Make sure individual colors have no spaces. For example, use `rgba(255,0,0,0.3)` instead of `rgba(255, 0, 0, 0.3)`. |
+| horizontal | boolean | Include to draw bars horizontally instead of vertically.                                                                                                                                                                                                                                                                                                                |
+| lollipop   | boolean | Include to draw lollipops instead of bars.                                                                                                                                                                                                                                                                                                                              |
+| maxPlaces  | number  | Maximum _number_ of child places to plot. Default: `7`.                                                                                                                                                                                                                                                                                                                 |
+| maxVariables  | number  | Maximum _number_ of varibales to plot. Default: show all variables.                                                                                                                                                                                                                                                                                                                 |
+| sort       | string  | Bar chart sort order. <br/><br/>Options: <br /> - `ascending` (ascending by the variable's value)<br /> - `descending` (descending by variable's value)<br /> - `ascendingPopulation` (ascending by the place's population)<br /> -`descendingPopulation` (descending by the place's population)<br /><br />Default: `descendingPopulation`                   |
+| stacked    | boolean | Include to draw as stacked bar chart instead of grouped chart.                                                                                                                                                                                                                                                                                                          |
 | subscribe    | string  | Listen for data changes on this event channel. Channel name should match the `publish` name on a control component. Example: [datacommons-slider](./slider.md)                                                                                                                                                                                                          |
-
 {: .doc-table }
 
 ### Advanced Configuration
 
-| Name                | Type    | Description                                                                                                                                                                                                                                                                                |
-| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| apiRoot             | string  | Domain to make data fetch API calls from. Used primarily for fetching data from custom DCs.<br /><br />Default: `https://datacommons.org`.                                                                                                                                                 |
-| defaultVariableName | string  | To be used with `variableNameRegex`. If specified and no variable name is extracted out with the regex, use this as the variable name. e.g., if the variableNameRegex is "(.\*?)(?=:)", and the defaultVariableName is "Total", for a variable named "variable 1", it will become "Total". |
-| placeNameProp       | string  | Optionally specify the property to use to get the place names.                                                                                                                                                                                                                             |
-| showExploreMore     | boolean | Include to show "Explore more" link in the footer, which takes the user to Datacommons.org's [visualization tools](https://datacommons.org/tools/visualization).                                                                                                                           |
-| variableNameRegex   | string  | Optionally specify regex to use to extract out variable name. e.g., if the variableNameRegex is "(.\*?)(?=:)", only the part before a ":" will be used for variable names. So "variable 1: test" will become "variable 1".                                                                 |
-| yAxisMargin         | number  | Set size (in px) of y-axis' margin to fit the axis label text. Default: 60px.                                                                                                                                                                                                              |
-
+| Name                | Type   | Description                                                                                                                                                                                                                                                                                |
+| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| apiRoot         | string  | Domain to make data fetch API calls from. Used primarily for fetching data from custom DCs.<br /><br />Default: `https://datacommons.org`. |
+| defaultVariableName | string | To be used with `variableNameRegex`. If specified and no variable name is extracted out with the regex, use this as the variable name. e.g., if the variableNameRegex is "(.*?)(?=:)", and the defaultVariableName is "Total", for a variable named "variable 1", it will become "Total". |
+| placeNameProp   | string  | Optionally specify the property to use to get the place names.                                                                             |
+| showExploreMore | boolean | Include to show "Explore more" link in the footer, which takes the user to Datacommons.org's [visualization tools](https://datacommons.org/tools/visualization).                                        |
+| variableNameRegex   | string | Optionally specify regex to use to extract out variable name. e.g., if the variableNameRegex is "(.*?)(?=:)", only the part before a ":" will be used for variable names. So "variable 1: test" will become "variable 1".                                                                  |
+| yAxisMargin | number | Set size (in px) of y-axis' margin to fit the axis label text. Default: 60px. |
 {: .doc-table }
 
 ## Examples
@@ -100,7 +95,6 @@ permalink: /api/web_components/bar
 
 Code:
 {: .example-box-title}
-
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -109,7 +103,6 @@ Code:
   variables="Count_Person"
 ></datacommons-bar>
 ```
-
 {: .example-box-content}
 
 <div>
@@ -126,7 +119,6 @@ Code:
 
 Code:
 {: .example-box-title}
-
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -134,7 +126,6 @@ Code:
   places="geoId/01 geoId/02"
 ></datacommons-bar>
 ```
-
 {: .example-box-content}
 
 <div>
@@ -150,7 +141,6 @@ Code:
 
 Code:
 {: .example-box-title}
-
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -159,7 +149,6 @@ Code:
   stacked
 ></datacommons-bar>
 ```
-
 {: .example-box-content}
 
 <div>
@@ -176,7 +165,6 @@ Code:
 
 Code:
 {: .example-box-title}
-
 ```html
 <datacommons-bar
   header="Median income by gender"
@@ -187,7 +175,6 @@ Code:
   sort="descending"
 ></datacommons-bar>
 ```
-
 {: .example-box-content}
 
 <div>
@@ -206,7 +193,6 @@ Code:
 
 Code:
 {: .example-box-title}
-
 ```html
 <datacommons-bar
   header="Population of US States"
@@ -216,7 +202,6 @@ Code:
   lollipop
 ></datacommons-bar>
 ```
-
 {: .example-box-content}
 
 <div>

--- a/api/web_components/slider.md
+++ b/api/web_components/slider.md
@@ -10,13 +10,17 @@ permalink: /api/web_components/slider
 
 # Data Commons Slider Web Component
 
-[Data Commons Web Component](/api/web_components/) for controlling the date in [datacommons-map](./map.md).
+[Data Commons Web Component](/api/web_components/) for controlling the date in [datacommons-map](./map.md) or 
+[datacommons-bar](./bar.md).
 
 ## Usage
 
 <div class="api-tab">
   <button id="get-button" class="api-tablink" onclick="openTab(event, 'map-tab')">
     Control a map
+  </button>
+  <button class="api-tablink" onclick="openTab(event, 'bar-tab')">
+    Control a bar chart
   </button>
 </div>
 
@@ -36,6 +40,27 @@ permalink: /api/web_components/slider
 ></datacommons-slider>
 ```
 {: #map-tab .api-tabcontent}
+
+```html
+<!-- Bar chart listening for date change events on the "dc-bar" channel -->
+<datacommons-bar
+  header="Count_Person_InLaborForce and sdg/SI_POV_DAY1 (${date})"
+  variables="sdg/SI_POV_DAY1"
+  places="country/USA country/RUS country/MEX"
+  subscribe="dc-bar"
+  date="HIGHEST_COVERAGE"
+>
+  <!-- Place slider in the component's footer and publish events on the "dc-bar" channel -->
+  <datacommons-slider
+    variables="sdg/SI_POV_DAY1"
+    places="country/USA country/RUS country/MEX"
+    publish="dc-bar"
+    slot="footer"
+    >
+  </datacommons-slider>
+</datacommons-bar>
+```
+{: #bar-tab .api-tabcontent}
 
 <script src="/assets/js/syntax_highlighting.js"></script>
 <script src="/assets/js/api-doc-tabs.js"></script>
@@ -70,12 +95,12 @@ permalink: /api/web_components/slider
 
 ## Examples
 
-### Example 1: Use slider to change dates on a datacommons map web component
+### Example 1: Use slider to change dates on a `datacommons-map` web component
 
 Code:
 {: .example-box-title}
 ```html
-<!-- Listen for date changes on the "dc-year" channel -->
+<!-- Listen for date changes on the "dc-map" channel -->
 <datacommons-map
   header="Population"
   parentPlace="country/USA"
@@ -84,7 +109,7 @@ Code:
   variable="Count_Person"
 ></datacommons-map>
 
-<!-- Publish date changes on the "dc-year" channel  -->
+<!-- Publish date changes on the "dc-map" channel  -->
 <datacommons-slider
   publish="dc-map"
   variable="Count_Person"
@@ -94,7 +119,7 @@ Code:
 ```
 {: .example-box-content}
 
-<!-- Listen for date changes on the "dc-year" channel -->
+<!-- Listen for date changes on the "dc-map" channel -->
 <datacommons-map
   header="Population"
   parentPlace="country/USA"
@@ -103,10 +128,54 @@ Code:
   variable="Count_Person"
 ></datacommons-map>
 
-<!-- Publish date changes on the "dc-year" channel  -->
+<!-- Publish date changes on the "dc-map" channel  -->
 <datacommons-slider
   publish="dc-map"
   variable="Count_Person"
   parentPlace="country/USA"
   childPlaceType="State"
 ></datacommons-slider>
+
+### Example 2: Use slider to change dates on a `datacommons-bar` web component
+
+Code:
+{: .example-box-title}
+```html
+<!-- Bar chart listening for date change events on the "dc-bar" channel -->
+<datacommons-bar
+  header="Count_Person_InLaborForce and sdg/SI_POV_DAY1 (${date})"
+  variables="sdg/SI_POV_DAY1"
+  places="country/USA country/RUS country/MEX"
+  subscribe="dc-bar"
+  date="HIGHEST_COVERAGE"
+>
+  <!-- Place slider in the component's footer and publish events on the "dc-bar" channel -->
+  <datacommons-slider
+    variables="sdg/SI_POV_DAY1"
+    places="country/USA country/RUS country/MEX"
+    publish="dc-bar"
+    slot="footer"
+    >
+  </datacommons-slider>
+</datacommons-bar>
+```
+{: .example-box-content}
+
+
+<!-- Bar chart listening for date change events on the "dc-bar" channel -->
+<datacommons-bar
+  header="Count_Person_InLaborForce and sdg/SI_POV_DAY1 (${date})"
+  variables="sdg/SI_POV_DAY1"
+  places="country/USA country/RUS country/MEX"
+  subscribe="dc-bar"
+  date="HIGHEST_COVERAGE"
+>
+  <!-- Place slider in the component's footer and publish events on the "dc-bar" channel -->
+  <datacommons-slider
+    variables="sdg/SI_POV_DAY1"
+    places="country/USA country/RUS country/MEX"
+    publish="dc-bar"
+    slot="footer"
+    >
+  </datacommons-slider>
+</datacommons-bar>

--- a/api/web_components/slider.md
+++ b/api/web_components/slider.md
@@ -44,7 +44,7 @@ permalink: /api/web_components/slider
 ```html
 <!-- Bar chart listening for date change events on the "dc-bar" channel -->
 <datacommons-bar
-  header="Count_Person_InLaborForce and sdg/SI_POV_DAY1 (${date})"
+  header="Population below the poverty line in the US, Russia, and Mexico (${date})"
   variables="sdg/SI_POV_DAY1"
   places="country/USA country/RUS country/MEX"
   subscribe="dc-bar"
@@ -143,7 +143,7 @@ Code:
 ```html
 <!-- Bar chart listening for date change events on the "dc-bar" channel -->
 <datacommons-bar
-  header="Count_Person_InLaborForce and sdg/SI_POV_DAY1 (${date})"
+  header="Population below the poverty line in the US, Russia, and Mexico (${date})"
   variables="sdg/SI_POV_DAY1"
   places="country/USA country/RUS country/MEX"
   subscribe="dc-bar"
@@ -164,7 +164,7 @@ Code:
 
 <!-- Bar chart listening for date change events on the "dc-bar" channel -->
 <datacommons-bar
-  header="Count_Person_InLaborForce and sdg/SI_POV_DAY1 (${date})"
+  header="Population below the poverty line in the US, Russia, and Mexico (${date})"
   variables="sdg/SI_POV_DAY1"
   places="country/USA country/RUS country/MEX"
   subscribe="dc-bar"


### PR DESCRIPTION
- Documenting a [new feature](https://github.com/datacommonsorg/website/pull/4525) that allows the datacommons-bar web component to change its date based on the datacommons-slider control
- Updated datacommons-slider instructions to include bar chart examples
- Updated datcommons-bar instructions to include `subscribe` property


Screenshot
![5gJ95BF6mFNyvNw](https://github.com/user-attachments/assets/4331ac91-8c68-4593-888a-caa6855b4919)


NOTE: Do not merge until [website/4525](https://github.com/datacommonsorg/website/pull/4525) is in production

