### PR TITLE
Implement redirect_from and clean up redirect pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # To upgrade, run `bundle update github-pages`.
 gem "github-pages", group: :jekyll_plugins
-gem 'jekyll-redirect-from'
+
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
@@ -17,6 +17,7 @@ end
 group :jekyll_plugins do  
   gem "jekyll-tabs"
   gem "jekyll-relative-links"
+  gem 'jekyll-redirect-from'
 end
 
 gem "webrick", "~> 1.8"

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,14 +1,14 @@
 <html>
   <head>
       <meta charset="utf-8"/>
-      <meta http-equiv="refresh" content="1;url={{ page.redirect }}"/>
-      <link rel="canonical" href="{{ page.redirect }}"/>
+      <meta http-equiv="refresh" content="0;url={{ page.redirect.to }}"/>
+      <link rel="canonical" href="{{ page.redirect.to }}"/>
       <script type="text/javascript">
-              window.location.href = "{{ page.redirect }}"
+              window.location.href = "{{ page.redirect.to }}"
       </script>
       <title>Page Redirection</title>
   </head>
   <body>
-  The content has moved. If you are not redirected automatically, please follow <a href='{{ page.redirect }}'>this link</a>.
+  The content has moved. If you are not redirected automatically, please follow <a href='{{ page.redirect.to }}'>this link</a>.
   </body>
   </html>

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -4,6 +4,9 @@ title: Python
 nav_order: 40
 parent: API
 has_children: true
+redirect_from:
+    /tutorials/
+    /tutorials/index
 ---
 
 # Data Commons Python API

--- a/api/rest/v2/getting_started.md
+++ b/api/rest/v2/getting_started.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /api/rest/v2/index.html
-nav_exclude: true
----

--- a/api/rest/v2/index.md
+++ b/api/rest/v2/index.md
@@ -5,6 +5,8 @@ nav_order: 5
 parent: API
 has_children: true
 published: true
+redirect_from: 
+  - / api/rest/v2/getting_started
 ---
 
 {:.no_toc}

--- a/bigquery/data_in_bq.md
+++ b/bigquery/data_in_bq.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /data_model.html
----

--- a/bigquery/dc_to_bq_queries.md
+++ b/bigquery/dc_to_bq_queries.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: index.html
----

--- a/bigquery/index.md
+++ b/bigquery/index.md
@@ -3,6 +3,8 @@ layout: default
 title: Query with SQL/BigQuery
 nav_order: 30
 has_children: true
+redirect_from:
+    /bigquery/dc_to_bq_queries
 ---
 
 # Query Data Commons using SQL with BigQuery

--- a/bigquery/unique_identifiers.md
+++ b/bigquery/unique_identifiers.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /data_model.html#dcid
----

--- a/blog.html
+++ b/blog.html
@@ -1,5 +1,5 @@
 ---
 layout: redirect
 title: Blog
-redirect: https://blog.datacommons.org/
+redirect_to: https://blog.datacommons.org/
 ---

--- a/courseware/data_literacy/index.md
+++ b/courseware/data_literacy/index.md
@@ -1,8 +1,0 @@
----
-layout: redirect
-title: Data Literacy with Data Commons
-nav_order: 1
-parent: Courseware
-has_children: true
-redirect: overview.html
----

--- a/courseware/data_literacy/overview.md
+++ b/courseware/data_literacy/overview.md
@@ -4,6 +4,8 @@ title: Overview
 nav_order: 1
 parent: Data Literacy with Data Commons
 grand_parent: Courseware
+redirect_from:
+    /courseware/data_literacy/index
 ---
 
 # Data Literacy with Data Commons

--- a/csv_download.md
+++ b/csv_download.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect: https://datacommons.org/tools/download
+redirect_to: https://datacommons.org/tools/download
 ---

--- a/data_model.md
+++ b/data_model.md
@@ -2,6 +2,9 @@
 layout: default
 title: Key concepts and common tasks
 nav_order: 3
+redirect_from: 
+    /bigquery/data_in_bq
+    /bigquery/unique_identifiers#dcid
 ---
 
 {: .no_toc}

--- a/datasets/Disasters.md
+++ b/datasets/Disasters.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /datasets
----

--- a/datasets/covid19.md
+++ b/datasets/covid19.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /datasets
----

--- a/datasets/index.md
+++ b/datasets/index.md
@@ -3,6 +3,13 @@ layout: default
 title: Data Sources
 nav_order: 110
 has_children: true
+redirect_from:
+    - /datasets/covid19
+    - /datasets/international
+    - /datasets/sustainability
+    - /datasets/united_states
+    - /datasets/Disasters
+
 ---
 
 # Data Sources

--- a/datasets/international.md
+++ b/datasets/international.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /datasets
----

--- a/datasets/sustainability.md
+++ b/datasets/sustainability.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /datasets
----

--- a/datasets/united_states.md
+++ b/datasets/united_states.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect: /datasets
----

--- a/statistical_variables.md
+++ b/statistical_variables.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect: https://datacommons.org/tools/statvar
+redirect_to: https://datacommons.org/tools/statvar
 ---

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect: /api/python/tutorials.html
-nav_exclude: true
----


### PR DESCRIPTION
This PR allows to clean up all pages from the repo that only exist as redirects (and have the pages auto-generated at run time), with the exception of two pages that link outside the docsite.

See it in action at bullie.svl.corp.google.com:4000