### PR TITLE
Fixed redirect from /tutorials to /api/python/tutorials

### DIFF
--- a/api/python/index.md
+++ b/api/python/index.md
@@ -5,7 +5,7 @@ nav_order: 30
 parent: API - Query data programmatically
 has_children: true
 redirect_from:
-    /tutorials/
+    /tutorials
     /tutorials/index
 ---
 

--- a/api/python/index.md
+++ b/api/python/index.md
@@ -4,9 +4,6 @@ title: Python
 nav_order: 30
 parent: API - Query data programmatically
 has_children: true
-redirect_from:
-    /tutorials
-    /tutorials/index
 ---
 
 # Data Commons Python API

--- a/api/python/tutorials.md
+++ b/api/python/tutorials.md
@@ -4,6 +4,9 @@ title: Tutorials
 nav_order: 31
 parent: Python
 grand_parent: API - Query data programmatically
+redirect_from:
+    - /tutorials
+    - /tutorials/index
 ---
 
 # Tutorials

--- a/api/rest/v2/index.md
+++ b/api/rest/v2/index.md
@@ -5,8 +5,7 @@ nav_order: 1
 parent: API - Query data programmatically
 has_children: true
 published: true
-redirect_from: 
-  - / api/rest/v2/getting_started
+redirect_from: /api/rest/v2/getting_started
 ---
 
 {:.no_toc}

--- a/bigquery/index.md
+++ b/bigquery/index.md
@@ -3,8 +3,7 @@ layout: default
 title: Query with SQL/BigQuery
 nav_order: 70
 has_children: true
-redirect_from:
-    /bigquery/dc_to_bq_queries
+redirect_from: /bigquery/dc_to_bq_queries
 ---
 
 # Query Data Commons using SQL with BigQuery

--- a/courseware/data_literacy/index.md
+++ b/courseware/data_literacy/index.md
@@ -4,8 +4,7 @@ title: Data literacy with Data Commons
 nav_order: 221
 parent: Educational materials
 grand_parent: Additional resources
-redirect_from:
-    /courseware/data_literacy/overview
+redirect_from: /courseware/data_literacy/overview
 ---
 
 # Data literacy with Data Commons

--- a/data_model.md
+++ b/data_model.md
@@ -4,8 +4,8 @@ title: Key concepts and common tasks
 nav_order: 3
 parent: How to use Data Commons
 redirect_from: 
-    /bigquery/data_in_bq
-    /bigquery/unique_identifiers#dcid
+  - /bigquery/data_in_bq
+  - /bigquery/unique_identifiers#dcid
 ---
 
 {: .no_toc}

--- a/data_model.md
+++ b/data_model.md
@@ -5,7 +5,7 @@ nav_order: 3
 parent: How to use Data Commons
 redirect_from: 
   - /bigquery/data_in_bq
-  - /bigquery/unique_identifiers#dcid
+  - /bigquery/unique_identifiers
 ---
 
 {: .no_toc}

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect_to: /api/python/tutorials
+---

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect_to: /api/python/tutorials
----


### PR DESCRIPTION
Fixed redirects:

* `/tutorials` -> `/api/python/tutorials`
*  `/bigquery/data_in_bq` ->
* `/bigquery/unique_identifiers` -> `/data_model.html`
* `/bigquery/unique_identifiers#dcid` -> `/data_model.html` (the `#` is ignored)