### PR TITLE
Add link to troubleshooting guide to build_image.md

### DIFF
--- a/custom_dc/build_image.md
+++ b/custom_dc/build_image.md
@@ -143,3 +143,8 @@ Start the services using the locally built repo. If you have made changes to any
 [-v $PWD/static/custom_dc/custom:/workspace/static/custom_dc/custom \]
 <var>IMAGE_NAME</var>:<var>IMAGE_TAG</var>
 </pre>
+
+## Troubleshooting
+
+Having trouble? Visit our [Troubleshooting Guide](/custom_dc/troubleshooting.html) for detailed solutions to common problems.
+


### PR DESCRIPTION
@kmoscoe Added a link to the troubleshooting guide here to make it easy for users to find ( we were getting some questions that are answered in the guide ). Let me know if you think the wording is OK.