### PR TITLE
Update deprecated cache version

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       
       # Use GitHub Actions' cache to shorten build times and decrease load on servers
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}


### PR DESCRIPTION
There was a deprecation notice sent out last year: https://github.com/actions/cache/discussions/1510. The worfklow is now failing. Hopefully this will fix it.