### PR TITLE
Update MCP server name configuration and 2 other fixes

### DIFF
--- a/custom_dc/advanced.md
+++ b/custom_dc/advanced.md
@@ -82,7 +82,7 @@ If you have tried to start a container, and have received a `SQL check failed` e
 -e GOOGLE_APPLICATION_CREDENTIALS=/gcp/creds.json \
 -v $HOME/.config/gcloud/application_default_credentials.json:/gcp/creds.json:ro \
 -e DATA_RUN_MODE=schemaupdate
-gcr.io/datcom-ci/datacommons-data:stable
+gcr.io/datcom-ci/datacommons-data:stable</pre>
     </div>
     </div>
 </div>

--- a/custom_dc/advanced.md
+++ b/custom_dc/advanced.md
@@ -23,13 +23,30 @@ Before you proceed, ensure you have [set up all necessary GCP services](deploy_c
 
 ### Step 1: Set environment variables
 
-To run a local instance of the data management container, you need to set all of the environment variables in the `custom_dc/env.list` file, including all the GCP ones. 
+To run a local instance of the data management container, you need to set all of the GCP-related environment variables in the `custom_dc/env.list` file. 
 
-1. Obtain the values output by Terraform scripts: Go to <https://console.cloud.google.com/run/jobs>{: target="_blank"} for your project, select the relevant job from the list, and click **View and edit job configuration**. 
-1. Expand **Edit container**, and select the **Variables and secrets** tab.
-1. Copy the values of all the variables, with the exception of `FORCE_RESTART` and `INPUT_DIR` to your `env.list` file.
+1. Obtain the values output by Terraform scripts:
+    <div class="gcp-tab-group">
+      <ul class="gcp-tab-headers">
+        <li class="active">Cloud Console</li>
+        <li>gcloud CLI</li>
+      </ul>
+      <div class="gcp-tab-content">
+          <div class="active">
+            <ol>
+              <li>Go to <a href="https://console.cloud.google.com/run/jobs" target="_blank">https://console.cloud.google.com/run/jobs</a> for your project, select the relevant job from the list, and click <b>View and edit job configuration</b>. </li>
+               <li>Scroll to the <b>Containers</b> and select the <b>Variables & Secrets</b> tab. </li>
+              <li>To retrieve the values of secrets, click on the links to the Secret Manager, and click <b>Actions</b> > <b>View secret value</b>. </li>
+            </ol>
+          </div>
+          <div>
+            <ol>
+          <li>Run the following command:
+              <pre>gcloud run jobs describe <var>JOB_NAME</var> --region <var>REGION</var></pre></li>
+          <li>To get the values of the secrets, run the following command for each secret listed in the <b>Secrets</b> section of the output:
+              <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre>.</li></ol></div></div></div>
+1. In your `env.list` file, copy the values obtained in the previous step, with the exception of `FORCE_RESTART`.
 1. Set the value of `INPUT_DIR` to the full local path where your CSV, JSON, and MCF files are located.
-1. Set the value of `OUTPUT_DIR` to the Google Cloud Storage folder where the output should be written, in the form <code>gs://<var>GCS_BUCKET</var>/output</code>.
 
 ### Step 2: Run the data management Docker container
 
@@ -101,8 +118,27 @@ Before you proceed, ensure you have [set up all necessary GCP services](deploy_c
 
 To run a local instance of the services container, you need to set all of the environment variables in the `custom_dc/env.list` file, including all the GCP ones. 
 
-1. Obtain the values output by Terraform scripts: Go to <https://console.cloud.google.com/run/services>{: target="_blank"} for your project, select the relevant service from the list, and click the **Revisions** tab. 
-1. In the right-hand window, scroll to **Environment variables**.
+1. Obtain the values output by Terraform scripts:
+    <div class="gcp-tab-group">
+      <ul class="gcp-tab-headers">
+        <li class="active">Cloud Console</li>
+        <li>gcloud CLI</li>
+      </ul>
+      <div class="gcp-tab-content">
+          <div class="active">
+            <ol>
+              <li>Go to <a href="https://console.cloud.google.com/run/services" target="_blank">https://console.cloud.google.com/run/services</a> for your project, and select the relevant service from the list.</li>
+              <li>In the <b>Service details</b> screen, click the <b>Revisions</b> tab.</li>
+              <li>in the right-hand window, select the <b>Containers</b> tab and scroll down to the <b>Environment variables</b> section.</li>
+              <li>To retrieve the values of secrets, click on the links to the Secret Manager, and click <b>Actions</b> > <b>View secret value</b>. </li>
+            </ol>
+          </div>
+          <div>
+            <ol>
+          <li>Run the following command:
+              <pre>gcloud run services describe <var>SERVICE_NAME</var> --region <var>REGION</var></pre></li>
+          <li>To get the values of the secrets, run the following command for each secret listed in the <b>Secrets</b> section of the output:
+              <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre>.</li></ol></div></div></div>
 1. Copy the values of all the variables, with the exception of `FORCE_RESTART`, to your `env.list` file.
 
 {: #step2}

--- a/custom_dc/advanced.md
+++ b/custom_dc/advanced.md
@@ -134,7 +134,7 @@ To run a local instance of the services container, you need to set all of the GC
             <ol>
               <li>Go to <a href="https://console.cloud.google.com/run/services" target="_blank">https://console.cloud.google.com/run/services</a> for your project, and select the relevant service from the list.</li>
               <li>In the <b>Service details</b> screen, click the <b>Revisions</b> tab.</li>
-              <li>in the right-hand window, select the <b>Containers</b> tab and scroll down to the <b>Environment variables</b> section.</li>
+              <li>In the right-hand window, select the <b>Containers</b> tab and scroll down to the <b>Environment variables</b> section.</li>
               <li>Look up the name of the secret for the <code>DB_PASS</code> variable. It is in the form <code><var>NAMESPACE</var>-datacommons-mysql-password</code>.</li>
               <li>Go to <a href="https://console.cloud.google.com/secret-manager" target="_blank">https://console.cloud.google.com/secret-manager</a> and in the list of secrets, click on the link of the secret name. </li>
               <li>Select <b>Actions</b> > <b>View secret value</b>.</li>

--- a/custom_dc/advanced.md
+++ b/custom_dc/advanced.md
@@ -47,6 +47,7 @@ To run a local instance of the data management container, you need to set all of
               <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre>.</li></ol></div></div></div>
 1. In your `env.list` file, copy the values obtained in the previous step, with the exception of `FORCE_RESTART`.
 1. Set the value of `INPUT_DIR` to the full local path where your CSV, JSON, and MCF files are located.
+1. If needed, update the value of `OUTPUT_DIR` to the Google Cloud Storage folder where the output should be written, in the form <code>gs://<var>GCS_BUCKET</var>/output</code>.
 
 ### Step 2: Run the data management Docker container
 
@@ -116,7 +117,7 @@ Before you proceed, ensure you have [set up all necessary GCP services](deploy_c
 
 ### Step 1: Set environment variables
 
-To run a local instance of the services container, you need to set all of the environment variables in the `custom_dc/env.list` file, including all the GCP ones. 
+To run a local instance of the services container, you need to set all of the GCP-related environment variables in the `env.list` file.
 
 1. Obtain the values output by Terraform scripts:
     <div class="gcp-tab-group">

--- a/custom_dc/advanced.md
+++ b/custom_dc/advanced.md
@@ -35,19 +35,23 @@ To run a local instance of the data management container, you need to set all of
           <div class="active">
             <ol>
               <li>Go to <a href="https://console.cloud.google.com/run/jobs" target="_blank">https://console.cloud.google.com/run/jobs</a> for your project, select the relevant job from the list, and click <b>View and edit job configuration</b>. </li>
-               <li>Scroll to the <b>Containers</b> and select the <b>Variables & Secrets</b> tab. </li>
-              <li>To retrieve the values of secrets, click on the links to the Secret Manager, and click <b>Actions</b> > <b>View secret value</b>. </li>
+               <li>Under the <b>Containers</b> tab, select the <b>Variables & Secrets</b> tab. </li>
+              <li>Look up the name of the secret for the <code>DB_PASS</code> variable. It is in the form <code><var>NAMESPACE</var>-datacommons-mysql-password</code>.</li>
+              <li>Go to <a href="https://console.cloud.google.com/secret-manager" target="_blank">https://console.cloud.google.com/secret-manager</a> and in the list of secrets, click on the link of the secret name. </li>
+              <li>Select <b>Actions</b> > <b>View secret value</b>. Copy the value to your <code>env.list</code> file.</li>
             </ol>
           </div>
           <div>
             <ol>
           <li>Run the following command:
               <pre>gcloud run jobs describe <var>JOB_NAME</var> --region <var>REGION</var></pre></li>
-          <li>To get the values of the secrets, run the following command for each secret listed in the <b>Secrets</b> section of the output:
-              <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre>.</li></ol></div></div></div>
-1. In your `env.list` file, copy the values obtained in the previous step, with the exception of `FORCE_RESTART`.
+          <li>From the <code>Secrets</code> section of the output, note the name of the <code>DB_PASS</code> secret. It is in the form <code><var>NAMESPACE</var>-datacommons-mysql-password</code>.</li>
+          <li>Run this command to obtain its value:
+              <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre></li>
+              </ol></div></div></div>
+1. Copy all of the variable values obtained above into your `env.list` file, with the exception of `FORCE_RESTART` and `INPUT_DIR`.
 1. Set the value of `INPUT_DIR` to the full local path where your CSV, JSON, and MCF files are located.
-1. If needed, update the value of `OUTPUT_DIR` to the Google Cloud Storage folder where the output should be written, in the form <code>gs://<var>GCS_BUCKET</var>/output</code>.
+1. If needed, update the value of `OUTPUT_DIR` to the Google Cloud Storage folder where the output should be written, in the form <code>gs://<var>GCS_BUCKET</var>/<var>FOLDER</var></code>.
 
 ### Step 2: Run the data management Docker container
 
@@ -131,16 +135,20 @@ To run a local instance of the services container, you need to set all of the GC
               <li>Go to <a href="https://console.cloud.google.com/run/services" target="_blank">https://console.cloud.google.com/run/services</a> for your project, and select the relevant service from the list.</li>
               <li>In the <b>Service details</b> screen, click the <b>Revisions</b> tab.</li>
               <li>in the right-hand window, select the <b>Containers</b> tab and scroll down to the <b>Environment variables</b> section.</li>
-              <li>To retrieve the values of secrets, click on the links to the Secret Manager, and click <b>Actions</b> > <b>View secret value</b>. </li>
+              <li>Look up the name of the secret for the <code>DB_PASS</code> variable. It is in the form <code><var>NAMESPACE</var>-datacommons-mysql-password</code>.</li>
+              <li>Go to <a href="https://console.cloud.google.com/secret-manager" target="_blank">https://console.cloud.google.com/secret-manager</a> and in the list of secrets, click on the link of the secret name. </li>
+              <li>Select <b>Actions</b> > <b>View secret value</b>.</li>
             </ol>
           </div>
           <div>
             <ol>
           <li>Run the following command:
               <pre>gcloud run services describe <var>SERVICE_NAME</var> --region <var>REGION</var></pre></li>
-          <li>To get the values of the secrets, run the following command for each secret listed in the <b>Secrets</b> section of the output:
-              <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre>.</li></ol></div></div></div>
-1. Copy the values of all the variables, with the exception of `FORCE_RESTART`, to your `env.list` file.
+           <li>From the <code>Secrets</code> section of the output, note the name of the <code>DB_PASS</code> secret. It is in the form <code><var>NAMESPACE</var>-datacommons-mysql-password</code>.</li>
+          <li>Run this command to obtain its value:
+              <pre>gcloud secrets versions access latest --secret=<var>SECRET_ID</var></pre></li>
+              </ol></div></div></div>
+1. Copy all of the variable values obtained above into your `env.list` file, with the exception of `FORCE_RESTART`.
 
 {: #step2}
 ### Step 2: Run the services Docker container

--- a/custom_dc/deploy_cloud.md
+++ b/custom_dc/deploy_cloud.md
@@ -172,7 +172,7 @@ To upload data files:
     <ol>
          <li>Navigate to your local "input" directory where your source files are located.</li>
          <li>Run the following command:
-             <pre>gcloud storage cp config.json [<var>PATH</var>/]*.csv  [<var>PATH</var>/]*.mcf gs://<var>BUCKET_NAME</var>/<var>input</var> --region</pre>
+             <pre>gcloud storage cp config.json [<var>PATH</var>/]*.csv  [<var>PATH</var>/]*.mcf gs://<var>BUCKET_NAME</var>/<var>input</var></pre>
           <p>The path names are only required if you are using subdirectories to store your files.</p>
         </li>
       </ol>
@@ -431,8 +431,9 @@ Before running this procedure, please see [Required directory structure](mcp.md#
   </ul>
   <div class="gcp-tab-content">
    <div class="active">
+   <p>Step 1: Upload your files to Google Cloud Storage:
       <ol>
-        <li>Go to <a href="https://console.cloud.google.com/storage/browse" target="_blank">https://console.cloud.google.com/storage/browse</a> for your service and select the [Data Commons bucket](#data) that was created by the Terraform script.</li>
+        <li>Go to <a href="https://console.cloud.google.com/storage/browse" target="_blank">https://console.cloud.google.com/storage/browse</a> for your service and select the <a href="#data">Data Commons bucket</a> that was created by the Terraform script.</li>
         <li>Click <b>Create folder</b>.</li>
         <li>In the <b>Create folder</b> dialog, provide a name for the folder. It can be anything you want; for example, `mcp_instructions`.</li>
         <li>Click on the link of the new folder you just created, and click <b>Create folder</b> again.</li>
@@ -464,7 +465,7 @@ Before running this procedure, please see [Required directory structure](mcp.md#
           The instructions folder can be any name you want.
         </li>
       </ol>
-</p>
+      </p>
   <p>Step 2: Set the environment variable and restart the Cloud Run service:</p>
   <p>From any local directory, run the following command:
       <pre>gcloud run deploy <var>SERVICE_NAME</var> --image <var>CONTAINER_IMAGE_URL</var> --set-env-vars DC_INSTRUCTIONS_DIR=gs://<var>GCS_BUCKET</var>/<var>INSTRUCTIONS_FOLDER</var> --region <var>REGION</var></pre>

--- a/custom_dc/deploy_cloud.md
+++ b/custom_dc/deploy_cloud.md
@@ -234,7 +234,7 @@ If you have tried to start a container, and have received a `SQL check failed` e
       </div>
     <div>
    <p>From any local directory, run the following command:
-            <pre>gcloud run jobs execute <var>JOB_NAME</var> -update-env-vars DATA_RUN_MODE=schemaupdate --region <var>REGION</var></pre>
+            <pre>gcloud run jobs execute <var>JOB_NAME</var> --update-env-vars DATA_RUN_MODE=schemaupdate --region <var>REGION</var></pre>
          </p>
    </div>
   </div>

--- a/custom_dc/deploy_cloud.md
+++ b/custom_dc/deploy_cloud.md
@@ -172,7 +172,7 @@ To upload data files:
     <ol>
          <li>Navigate to your local "input" directory where your source files are located.</li>
          <li>Run the following command:
-             <pre>gcloud storage cp config.json [<var>PATH</var>/]*.csv  [<var>PATH</var>/]*.mcf gs://<var>BUCKET_NAME</var>/<var>input</var></pre>
+             <pre>gcloud storage cp config.json [<var>PATH</var>/]*.csv  [<var>PATH</var>/]*.mcf gs://<var>BUCKET_NAME</var>/<var>input</var> --region</pre>
           <p>The path names are only required if you are using subdirectories to store your files.</p>
         </li>
       </ol>
@@ -205,7 +205,7 @@ Every time you upload new input files to Google Cloud Storage, you will need to 
       </div>
     <div>
     <p>From any local directory, run the following command:
-           <pre>gcloud run jobs execute <var>JOB_NAME</var></pre>
+           <pre>gcloud run jobs execute <var>JOB_NAME</var> --region <var>REGION</var></pre>
   </p>
       </div>
       </div>
@@ -234,7 +234,7 @@ If you have tried to start a container, and have received a `SQL check failed` e
       </div>
     <div>
    <p>From any local directory, run the following command:
-            <pre>gcloud run jobs execute <var>JOB_NAME</var> -update-env-vars DATA_RUN_MODE=schemaupdate</pre>
+            <pre>gcloud run jobs execute <var>JOB_NAME</var> -update-env-vars DATA_RUN_MODE=schemaupdate --region <var>REGION</var></pre>
          </p>
    </div>
   </div>
@@ -311,7 +311,7 @@ Alternatively, you can use the following procedure.
      </ol>
   </div>
   <div><p>From any local directory, run the following command:
-      <pre>gcloud run deploy <var>SERVICE_NAME</var> --image gcr.io/datcom-ci/datacommons-services:stable [<var>OTHER_OPTIONS...</var>]</pre>
+      <pre>gcloud run deploy <var>SERVICE_NAME</var> --image gcr.io/datcom-ci/datacommons-services:stable --region <var>REGION</var> [<var>OTHER_OPTIONS...</var>]</pre>
       You can specify any options as flags (see the <a href="https://docs.cloud.google.com/sdk/gcloud/reference/run/deploy" target="_blank">gcloud deploy reference documentation</a>). For example, to add or change an environment variable, use <code>--set-env-vars</code>.
       </p>
   </div>
@@ -361,7 +361,7 @@ If you want to switch the prebuilt image or use a custom image, use the followin
       </ol>
     </div>
     <div><p>From any local directory, run the following command:
-      <pre>gcloud run deploy <var>SERVICE_NAME</var> --image <var>CONTAINER_IMAGE_URL</var>  [<var>OTHER_OPTIONS...</var>]</pre>
+      <pre>gcloud run deploy <var>SERVICE_NAME</var> --image <var>CONTAINER_IMAGE_URL</var> --region <var>REGION</var> [<var>OTHER_OPTIONS...</var>]</pre>
       The container image URL is the name of a <a href="image.md#prebuilt">prebuilt image</a>, or the package name of a container you have <a href="#upload">uploaded to the Artifact Registry</a>.</p>
      </p>
     </div>
@@ -467,7 +467,7 @@ Before running this procedure, please see [Required directory structure](mcp.md#
 </p>
   <p>Step 2: Set the environment variable and restart the Cloud Run service:</p>
   <p>From any local directory, run the following command:
-      <pre>gcloud run deploy <var>SERVICE_NAME</var> --image <var>CONTAINER_IMAGE_URL</var> --set-env-vars DC_INSTRUCTIONS_DIR=gs://<var>GCS_BUCKET</var>/<var>INSTRUCTIONS_FOLDER</var></pre>
+      <pre>gcloud run deploy <var>SERVICE_NAME</var> --image <var>CONTAINER_IMAGE_URL</var> --set-env-vars DC_INSTRUCTIONS_DIR=gs://<var>GCS_BUCKET</var>/<var>INSTRUCTIONS_FOLDER</var> --region <var>REGION</var></pre>
       <ul>
       <li>The container image URL is a prebuilt Data Commons image, or a custom image you have previously uploaded to the artifact registry.</li>
       <li>The instructions folder is the one you created in the previous step, specified in the form <code>gs://<var>GCS_BUCKET</var>/<var>INSTRUCTIONS_FOLDER</var></code>.</li>
@@ -489,13 +489,13 @@ To connect an AI agent to the Cloud Run service app:
     <pre>{
       ...
       "mcpServers": {
-          "datacommons-mcp": {         
+          "<var>SERVER_NAME</var>": {         
              "httpUrl": "<var>APP_URL</var>/mcp"
           }
       }
       ...
     }</pre>
-
+   The server name can be anything you want, for example, `datacommons-mcp-custom`.
 1. Run the agent as usual.
 
 ## Update your Terraform deployment {#update-terraform}

--- a/mcp/host_server.md
+++ b/mcp/host_server.md
@@ -39,7 +39,7 @@ To instruct Gemini CLI to start up a local server using Stdio, replace the `data
 {
    ...
    "mcpServers": {
-      # This can be any name you want, e.g. 'datacommons-mcp-local'
+      // This can be any name you want, e.g. 'datacommons-mcp-local'
       "<var>SERVER_NAME</var>": {
          "command": "uvx",
          "args": [

--- a/mcp/host_server.md
+++ b/mcp/host_server.md
@@ -114,7 +114,7 @@ The server is addressable with the endpoint `mcp`. For example, `http://my-mcp-s
    <pre>
    {
       "mcpServers": {
-         # This can be anything you want, e.g. 'datacommons-mcp-remote'
+         // This can be anything you want, e.g. 'datacommons-mcp-remote'
          "<var>SERVER_NAME</var>": {
            "httpUrl": "http://<var>HOST</var>:<var>PORT</var>/mcp",
            "headers": {

--- a/mcp/host_server.md
+++ b/mcp/host_server.md
@@ -39,7 +39,8 @@ To instruct Gemini CLI to start up a local server using Stdio, replace the `data
 {
    ...
    "mcpServers": {
-      "datacommons-mcp": {
+      # This can be any name you want, e.g. 'datacommons-mcp-local'
+      "<var>SERVER_NAME</var>": {
          "command": "uvx",
          "args": [
             "datacommons-mcp@latest",
@@ -52,6 +53,7 @@ To instruct Gemini CLI to start up a local server using Stdio, replace the `data
    }
    ...
 }
+
 </pre>
 
 [Run Gemini CLI](run_tools.md#run-gemini) as usual.
@@ -112,7 +114,8 @@ The server is addressable with the endpoint `mcp`. For example, `http://my-mcp-s
    <pre>
    {
       "mcpServers": {
-         "datacommons-mcp": {
+         # This can be anything you want, e.g. 'datacommons-mcp-remote'
+         "<var>SERVER_NAME</var>": {
            "httpUrl": "http://<var>HOST</var>:<var>PORT</var>/mcp",
            "headers": {
              "Accept": "application/json, text/event-stream"


### PR DESCRIPTION
This is a follow-up from the previous PR, which changes the Gemini config example to use a different name for the MCP server in all instances. It also makes the following other changes:
- Adds the --region command which is required in the gcloud run commands
- Adds gcloud commands for getting Cloud Run environment variables
- Adds Console and CLI procedures for getting the DB_PASS variable created by Terraform

Staged at http://bullie.svl.corp.google.com:4000